### PR TITLE
Problem: tracking memory context for non-by-value types

### DIFF
--- a/cppgres/executor.h
+++ b/cppgres/executor.h
@@ -152,7 +152,8 @@ struct spi_executor : public executor {
               ffi_guarded(::SPI_getbinval)(tuptable->vals[n], tuptable->tupdesc, Is + 1, &isnull);
           ::NullableDatum datum = {.value = value, .isnull = isnull};
           auto nd = nullable_datum(datum);
-          return from_nullable_datum<utils::tuple_element_t<Is, T>>(nd);
+          return from_nullable_datum<utils::tuple_element_t<Is, T>>(
+              nd, memory_context(tuptable->tuptabcxt));
         }())...};
       }(std::make_index_sequence<utils::tuple_size_v<T>>{});
       tuples.emplace(std::next(tuples.begin(), n), std::in_place, ret);

--- a/cppgres/imports.h
+++ b/cppgres/imports.h
@@ -24,6 +24,7 @@ extern "C" {
 #include <nodes/execnodes.h>
 #include <utils/builtins.h>
 #include <utils/expandeddatum.h>
+#include <utils/memutils.h>
 #include <utils/tuplestore.h>
 #ifdef __cplusplus
 }

--- a/cppgres/types.h
+++ b/cppgres/types.h
@@ -69,27 +69,29 @@ template <> datum into_datum(const std::string_view &t) {
 }
 template <> datum into_datum(const std::string &t) { return into_datum(std::string_view(t)); }
 
-template <> size_t from_datum(const datum &d) {
+template <> size_t from_datum(const datum &d, std::optional<memory_context>) {
   return static_cast<size_t>(d.operator const ::Datum &());
 }
-template <> int64_t from_datum(const datum &d) {
+template <> int64_t from_datum(const datum &d, std::optional<memory_context>) {
   return static_cast<int64_t>(d.operator const ::Datum &());
 }
-template <> int32_t from_datum(const datum &d) {
+template <> int32_t from_datum(const datum &d, std::optional<memory_context>) {
   return static_cast<int32_t>(d.operator const ::Datum &());
 }
-template <> int16_t from_datum(const datum &d) {
+template <> int16_t from_datum(const datum &d, std::optional<memory_context>) {
   return static_cast<int16_t>(d.operator const ::Datum &());
 }
-template <> bool from_datum(const datum &d) {
+template <> bool from_datum(const datum &d, std::optional<memory_context>) {
   return static_cast<bool>(d.operator const ::Datum &());
 }
 
-template <> text from_datum(const datum &d) { return {d}; }
-template <> bytea from_datum(const datum &d) { return {d}; }
-template <> std::string_view from_datum(const datum &d) { return from_datum<text>(d); }
-template <> std::string from_datum(const datum &d) {
-  return std::string(from_datum<text>(d).operator std::string_view());
+template <> text from_datum(const datum &d, std::optional<memory_context> ctx) { return {d, ctx}; }
+template <> bytea from_datum(const datum &d, std::optional<memory_context> ctx) { return {d, ctx}; }
+template <> std::string_view from_datum(const datum &d, std::optional<memory_context> ctx) {
+  return from_datum<text>(d, ctx);
+}
+template <> std::string from_datum(const datum &d, std::optional<memory_context> ctx) {
+  return std::string(from_datum<text>(d, ctx).operator std::string_view());
 }
 
 } // namespace cppgres

--- a/tests/datum.h
+++ b/tests/datum.h
@@ -40,12 +40,12 @@ add_test(varlena_text, [](test_case &) {
 
   // Try memory context being gone
   {
-    auto ctx = cppgres::alloc_set_memory_context();
+    auto ctx = cppgres::memory_context(std::move(cppgres::alloc_set_memory_context()));
     auto p = ::CurrentMemoryContext;
     _assert(p != ctx);
     ::CurrentMemoryContext = ctx;
     auto nd1 = cppgres::nullable_datum(PointerGetDatum(::cstring_to_text("test1")));
-    auto s1 = cppgres::from_nullable_datum<cppgres::text>(nd1);
+    auto s1 = cppgres::from_nullable_datum<cppgres::text>(nd1, ctx);
     _assert(s1.get_memory_context() == ctx);
     ::CurrentMemoryContext = p;
     ctx.reset();

--- a/tests/spi.h
+++ b/tests/spi.h
@@ -281,4 +281,21 @@ add_test(spi_execute, ([](test_case &) {
            return result;
          }));
 
+add_test(spi_ptr_gone, ([](test_case &) {
+           bool result = true;
+           cppgres::text res = []() {
+             cppgres::spi_executor spi;
+             return spi.query<cppgres::text>("select 'hello'").begin()[0];
+           }();
+           bool exception_raised = false;
+           try {
+             res.operator std::string_view();
+           } catch (cppgres::pointer_gone_exception &e) {
+             exception_raised = true;
+           }
+           result = result && _assert(exception_raised);
+
+           return result;
+         }));
+
 } // namespace tests

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -18,13 +18,14 @@ PG_MODULE_MAGIC;
 #include <utils/date.h>
 }
 
+#include "tests.h"
+
 #include "datum.h"
 #include "errors.h"
 #include "function.h"
 #include "memory_context.h"
 #include "spi.h"
 #include "srf.h"
-#include "tests.h"
 #include "xact.h"
 
 test_case::test_case(std::string_view name, bool (*function)(test_case &c)) : function(function) {


### PR DESCRIPTION
I made a wrong assumption (having not thought it through) that any pointer behind a datum would be its own allocation. Of course it is not true. For example, when results returned from a query done over SPI, the data is allocated in tuples, not individually.

Solution: allow passing memory_context to from_nullable_datum/from_datum

This allows us to pass a _known_ memory context (if we do know it) to the constructor of the non-by-value type so that it can track it. We do this for SPI case because know the context there. In all other context, it'll assume top memory context, which is never reset.