### PR TITLE
Problem: having to reconstruct complex types

### DIFF
--- a/cppgres/executor.h
+++ b/cppgres/executor.h
@@ -215,12 +215,12 @@ struct spi_executor : public executor {
       throw std::runtime_error("not a current SPI executor");
     }
     constexpr size_t nargs = sizeof...(Args);
-    std::array<::Oid, nargs> types = {type_for<Args>().oid...};
+    std::array<::Oid, nargs> types = {type_traits<Args>::type_for().oid...};
     std::array<::Datum, nargs> datums = {into_nullable_datum(args)...};
     std::array<const char, nargs> nulls = {into_nullable_datum(args).is_null() ? 'n' : ' ' ...};
     auto rc = ffi_guarded(::SPI_execute_with_args)(query.data(), nargs, types.data(), datums.data(),
                                                    nulls.data(), false, 0);
-    if (rc == SPI_OK_SELECT) {
+    if (rc > 0) {
       //      static_assert(std::random_access_iterator<result_iterator<Ret>>);
       return results<Ret, Args...>(SPI_tuptable);
     } else {
@@ -234,7 +234,7 @@ struct spi_executor : public executor {
       throw std::runtime_error("not a current SPI executor");
     }
     constexpr size_t nargs = sizeof...(Args);
-    std::array<::Oid, nargs> types = {type_for<Args>().oid...};
+    std::array<::Oid, nargs> types = {type_traits<Args>::type_for().oid...};
     return spi_plan<Args...>(ffi_guarded(::SPI_prepare)(query.data(), nargs, types.data()));
   }
 
@@ -247,7 +247,7 @@ struct spi_executor : public executor {
     std::array<::Datum, nargs> datums = {into_nullable_datum(args)...};
     std::array<const char, nargs> nulls = {into_nullable_datum(args).is_null() ? 'n' : ' ' ...};
     auto rc = ffi_guarded(::SPI_execute_plan)(query, datums.data(), nulls.data(), false, 0);
-    if (rc == SPI_OK_SELECT) {
+    if (rc > 0) {
       //      static_assert(std::random_access_iterator<result_iterator<Ret>>);
       return results<Ret, Args...>(SPI_tuptable);
     } else {
@@ -261,7 +261,7 @@ struct spi_executor : public executor {
       throw std::runtime_error("not a current SPI executor");
     }
     constexpr size_t nargs = sizeof...(Args);
-    std::array<::Oid, nargs> types = {type_for<Args>().oid...};
+    std::array<::Oid, nargs> types = {type_traits<Args>::type_for().oid...};
     std::array<::Datum, nargs> datums = {into_nullable_datum(args)...};
     std::array<const char, nargs> nulls = {into_nullable_datum(args).is_null() ? 'n' : ' ' ...};
     auto rc = ffi_guarded(::SPI_execute_with_args)(query.data(), nargs, types.data(), datums.data(),
@@ -269,7 +269,7 @@ struct spi_executor : public executor {
     if (rc >= 0) {
       return SPI_processed;
     } else {
-      throw std::runtime_error("spi error");
+      throw std::runtime_error(std::format("spi error"));
     }
   }
 

--- a/cppgres/type.h
+++ b/cppgres/type.h
@@ -9,13 +9,13 @@
 #include "imports.h"
 #include "utils/utils.h"
 
-extern "C" {
-#include "utils/varlena.h"
-}
-
 namespace cppgres {
 
-struct type;
+struct type {
+  ::Oid oid;
+
+  std::string_view name() { return ::format_type_be(oid); }
+};
 
 template <typename T> struct type_traits {
   static bool is(type &t) {
@@ -26,17 +26,22 @@ template <typename T> struct type_traits {
     }
   }
   static bool is(type &&t) { return is(std::move(t)); }
+
+  static constexpr type type_for() = delete;
 };
 
-struct type {
-  ::Oid oid;
-
-  std::string_view name() { return ::format_type_be(oid); }
+template <typename T> requires std::is_reference_v<T>
+struct type_traits<T> {
+  static constexpr type type_for() {
+    return type_traits<std::remove_reference_t<utils::remove_optional_t<T>>>::type_for();
+  }
 };
 
 struct non_by_value_type : public type {
   friend struct datum;
 
+  non_by_value_type(std::pair<const struct datum &, std::optional<memory_context>> init)
+      : non_by_value_type(init.first, init.second) {}
   non_by_value_type(const struct datum &datum, std::optional<memory_context> ctx)
       : value_datum(datum),
         ctx(tracking_memory_context(ctx.has_value() ? *ctx : top_memory_context)) {}
@@ -58,12 +63,11 @@ struct non_by_value_type : public type {
 protected:
   datum value_datum;
   tracking_memory_context<memory_context> ctx;
-  void *ptr(bool tracked = true) {
+  void *ptr(bool tracked = true) const {
     if (tracked && ctx.resets() > 0) {
       throw pointer_gone_exception();
     }
-    return ffi_guarded(::pg_detoast_datum)(
-        reinterpret_cast<struct ::varlena *>(value_datum.operator const ::Datum &()));
+    return reinterpret_cast<void *>(value_datum.operator const ::Datum &());
   }
 };
 
@@ -72,15 +76,30 @@ static_assert(std::copy_constructible<non_by_value_type>);
 struct varlena : public non_by_value_type {
   using non_by_value_type::non_by_value_type;
 
-  operator void *() { return VARDATA_ANY(ptr()); }
+  operator void *() { return VARDATA_ANY(detoasted_ptr()); }
+
+  datum get_datum() const { return value_datum; }
+
+  bool is_detoasted() const { return detoasted != nullptr; }
+
+protected:
+  void *detoasted = nullptr;
+  // tracking_memory_context<memory_context> detoasted_ctx;
+  void *detoasted_ptr() {
+    if (detoasted != nullptr) {
+      return detoasted;
+    }
+    detoasted = ffi_guarded(::pg_detoast_datum)(reinterpret_cast<::varlena *>(ptr()));
+    // detoasted_ctx = tracking_memory_context(memory_context::for_pointer(detoasted));
+    return detoasted;
+  }
 };
 
 struct text : public varlena {
   using varlena::varlena;
 
   operator std::string_view() {
-    void *value = *this;
-    return {static_cast<char *>(value), VARSIZE_ANY_EXHDR(this->ptr())};
+    return {static_cast<char *>(this->operator void *()), VARSIZE_ANY_EXHDR(this->detoasted_ptr())};
   }
 };
 
@@ -90,18 +109,93 @@ struct bytea : public varlena {
   using varlena::varlena;
 
   operator byte_array() {
-    void *value = *this;
-    return {reinterpret_cast<std::byte *>(value), VARSIZE_ANY_EXHDR(this->ptr())};
+    return {reinterpret_cast<std::byte *>(this->operator void *()),
+            VARSIZE_ANY_EXHDR(this->detoasted_ptr())};
   }
 };
 
-template <typename T> constexpr type type_for() {
-  return type_for<std::remove_reference_t<utils::remove_optional_t<T>>>();
-}
+template <typename T>
+concept flattenable = requires(T t, std::span<std::byte> span) {
+  { T::type() } -> std::same_as<type>;
+  { t.flat_size() } -> std::same_as<std::size_t>;
+  { t.flatten_into(span) };
+  { T::restore_from(span) } -> std::same_as<T>;
+};
+
+template <flattenable T> struct expanded_varlena : public varlena {
+  using flattenable_type = T;
+  using varlena::varlena;
+
+  expanded_varlena()
+      : varlena(([]() {
+          auto ctx = memory_context(std::move(alloc_set_memory_context()));
+          auto *e = ctx.alloc<expanded>();
+          e->inner = T();
+          init(&e->hdr, ctx);
+          return std::make_pair(datum(PointerGetDatum(e)), ctx);
+        })()),
+        detoasted(true) {}
+
+  operator T &() {
+    auto *ptr = non_by_value_type::ptr();
+    if (detoasted) {
+      return (reinterpret_cast<expanded *>(ptr))->inner;
+    } else {
+      auto *ptr1 = reinterpret_cast<std::byte *>(varlena::operator void *());
+      auto ctx = memory_context(std::move(alloc_set_memory_context()));
+      auto *value = ctx.alloc<expanded>();
+      init(&value->hdr, ctx);
+      value->inner = T::restore_from(std::span(ptr1, VARSIZE_ANY_EXHDR(ptr)));
+      detoasted = true;
+      return value->inner;
+    }
+  }
+
+  datum get_expanded_datum() const {
+    if (!detoasted) {
+      throw std::runtime_error("hasn't been expanded yet");
+    }
+    return datum(
+        EOHPGetRWDatum(reinterpret_cast<::ExpandedObjectHeader *>(non_by_value_type::ptr())));
+  }
+
+private:
+  bool detoasted = false;
+  struct expanded {
+    ::ExpandedObjectHeader hdr;
+    T inner;
+  };
+
+  static void init(ExpandedObjectHeader *hdr, memory_context &ctx) {
+    using header = int32_t;
+
+    static const ::ExpandedObjectMethods eom = {
+        .get_flat_size =
+            [](ExpandedObjectHeader *eohptr) {
+              auto *e = reinterpret_cast<expanded *>(eohptr);
+              T *inner = &e->inner;
+              return inner->flat_size() + sizeof(header);
+            },
+        .flatten_into =
+            [](ExpandedObjectHeader *eohptr, void *result, size_t allocated_size) {
+              auto *e = reinterpret_cast<expanded *>(eohptr);
+              T *inner = &e->inner;
+              SET_VARSIZE(reinterpret_cast<header *>(result), allocated_size);
+              auto bytes = reinterpret_cast<std::byte *>(result) + sizeof(header);
+              std::span buffer(bytes, allocated_size - sizeof(header));
+              inner->flatten_into(buffer);
+            }};
+
+    ffi_guarded(::EOH_init_header)(hdr, &eom, ctx);
+  }
+};
+
+template <typename T>
+concept expanded_varlena_type = requires { typename T::flattenable_type; };
 
 template <typename T>
 concept has_a_type = requires {
-  { type_for<T>() } -> std::same_as<type>;
+  { type_traits<T>::type_for() } -> std::same_as<type>;
 };
 
 } // namespace cppgres

--- a/cppgres/utils/utils.h
+++ b/cppgres/utils/utils.h
@@ -93,6 +93,7 @@ template <typename T> struct tuple_traits_impl<T, std::enable_if_t<std::is_aggre
 
   template <std::size_t I> using tuple_element = boost::pfr::tuple_element<I, T>;
 };
+
 #endif
 
 template <typename T> using tuple_size = typename tuple_traits_impl<T>::tuple_size_type;


### PR DESCRIPTION
If one has to do some work on a complex type every time it is passed around, that's inconvenient and inefficient.

Solution: add support for expanded datums / varlenas

This brings a lot of changes to the core library.