### PR TITLE
Problem: can we use custom types?

### DIFF
--- a/src/cppgres/imports.h
+++ b/src/cppgres/imports.h
@@ -21,13 +21,16 @@ extern "C" {
 #include <postgres.h>
 #include <fmgr.h>
 // clang-format on
+#include <catalog/namespace.h>
 #include <catalog/pg_class.h>
+#include <catalog/pg_type.h>
 #include <executor/spi.h>
 #include <miscadmin.h>
 #include <nodes/execnodes.h>
 #include <utils/builtins.h>
 #include <utils/expandeddatum.h>
 #include <utils/memutils.h>
+#include <utils/syscache.h>
 #include <utils/tuplestore.h>
 #ifdef __cplusplus
 }

--- a/src/cppgres/syscache.h
+++ b/src/cppgres/syscache.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "datum.h"
+#include "guard.h"
+#include "imports.h"
+
+namespace cppgres {
+
+template <typename T> struct syscache_traits {
+  static constexpr ::SysCacheIdentifier cache_id = USERMAPPINGUSERSERVER;
+};
+
+template <> struct syscache_traits<Form_pg_type> {
+  static constexpr ::SysCacheIdentifier cache_id = TYPEOID;
+};
+
+template <typename T>
+concept syscached = requires(T t) {
+  { *t };
+  { syscache_traits<T>::cache_id } -> std::same_as<const ::SysCacheIdentifier &>;
+};
+
+template <syscached T, convertible_into_datum... D> struct syscache {
+  syscache(const D &...key) : syscache(syscache_traits<T>::cache_id, key...) {}
+  syscache(::SysCacheIdentifier cache_id, const D &...key)
+      requires(sizeof...(key) > 0 && sizeof...(key) < 5)
+  {
+    datum keys[4] = {datum_conversion<D>::into_datum(key)...};
+    tuple = ffi_guarded(::SearchSysCache)(cache_id, keys[0], keys[1], keys[2], keys[3]);
+
+    if (!HeapTupleIsValid(tuple)) {
+      throw std::runtime_error("invalid tuple");
+    }
+  }
+
+  ~syscache() { ReleaseSysCache(tuple); }
+
+  decltype(*std::declval<T>()) &operator*() { return *reinterpret_cast<T>(GETSTRUCT(tuple)); }
+  const decltype(*std::declval<T>()) &operator*() const {
+    return *reinterpret_cast<T>(GETSTRUCT(tuple));
+  }
+
+private:
+  HeapTuple tuple;
+};
+
+} // namespace cppgres

--- a/src/cppgres/types.h
+++ b/src/cppgres/types.h
@@ -1,5 +1,5 @@
 /**
-* \file
+ * \file
  */
 #pragma once
 
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "datum.h"
+#include "syscache.h"
 #include "type.h"
 
 namespace cppgres {
@@ -67,63 +68,64 @@ template <flattenable F> struct type_traits<expanded_varlena<F>> {
   static constexpr type type_for() { return F::type(); }
 };
 
-template <> datum into_datum(const size_t &t) { return datum(static_cast<::Datum>(t)); }
-template <> datum into_datum(const int64_t &t) { return datum(static_cast<::Datum>(t)); }
-template <> datum into_datum(const int32_t &t) { return datum(static_cast<::Datum>(t)); }
-template <> datum into_datum(const int16_t &t) { return datum(static_cast<::Datum>(t)); }
-template <> datum into_datum(const bool &t) { return datum(static_cast<::Datum>(t)); }
-template <> datum into_datum(const text &t) { return t.get_datum(); }
-template <> datum into_datum(const std::string_view &t) {
-  size_t sz = t.size();
-  void *result = ffi_guarded(::palloc)(sz + VARHDRSZ);
-  SET_VARSIZE(result, t.size() + VARHDRSZ);
-  memcpy(VARDATA(result), t.data(), sz);
-  return datum(reinterpret_cast<::Datum>(result));
-}
-template <> datum into_datum(const std::string &t) { return into_datum(std::string_view(t)); }
-template <flattenable F> datum into_datum(const expanded_varlena<F> &t) {
-  return t.get_expanded_datum();
-}
+template <> struct datum_conversion<oid> {
+  static oid from_datum(const datum &d, std::optional<memory_context>) {
+    return static_cast<oid>(d.operator const ::Datum &());
+  }
+
+  static datum into_datum(const oid &t) { return datum(static_cast<::Datum>(t)); }
+};
 
 template <> struct datum_conversion<size_t> {
   static size_t from_datum(const datum &d, std::optional<memory_context>) {
     return static_cast<size_t>(d.operator const ::Datum &());
   }
+
+  static datum into_datum(const size_t &t) { return datum(static_cast<::Datum>(t)); }
 };
 
 template <> struct datum_conversion<int64_t> {
   static int64_t from_datum(const datum &d, std::optional<memory_context>) {
     return static_cast<int64_t>(d.operator const ::Datum &());
   }
+
+  static datum into_datum(const int64_t &t) { return datum(static_cast<::Datum>(t)); }
 };
 
 template <> struct datum_conversion<int32_t> {
   static int32_t from_datum(const datum &d, std::optional<memory_context>) {
     return static_cast<int32_t>(d.operator const ::Datum &());
   }
+  static datum into_datum(const int32_t &t) { return datum(static_cast<::Datum>(t)); }
 };
 
 template <> struct datum_conversion<int16_t> {
   static int16_t from_datum(const datum &d, std::optional<memory_context>) {
     return static_cast<int16_t>(d.operator const ::Datum &());
   }
+  static datum into_datum(const int16_t &t) { return datum(static_cast<::Datum>(t)); }
 };
 
 template <> struct datum_conversion<bool> {
   static bool from_datum(const datum &d, std::optional<memory_context>) {
     return static_cast<bool>(d.operator const ::Datum &());
   }
+  static datum into_datum(const bool &t) { return datum(static_cast<::Datum>(t)); }
 };
 
 // Specializations for text and bytea:
 template <> struct datum_conversion<text> {
   static text from_datum(const datum &d, std::optional<memory_context> ctx) { return text{d, ctx}; }
+
+  static datum into_datum(const text &t) { return t.get_datum(); }
 };
 
 template <> struct datum_conversion<bytea> {
   static bytea from_datum(const datum &d, std::optional<memory_context> ctx) {
     return bytea{d, ctx};
   }
+
+  static datum into_datum(const bytea &t) { return t.get_datum(); }
 };
 
 // Specializations for std::string_view and std::string.
@@ -132,6 +134,14 @@ template <> struct datum_conversion<std::string_view> {
   static std::string_view from_datum(const datum &d, std::optional<memory_context> ctx) {
     return datum_conversion<text>::from_datum(d, ctx);
   }
+
+  static datum into_datum(const std::string_view &t) {
+    size_t sz = t.size();
+    void *result = ffi_guarded(::palloc)(sz + VARHDRSZ);
+    SET_VARSIZE(result, t.size() + VARHDRSZ);
+    memcpy(VARDATA(result), t.data(), sz);
+    return datum(reinterpret_cast<::Datum>(result));
+  }
 };
 
 template <> struct datum_conversion<std::string> {
@@ -139,10 +149,56 @@ template <> struct datum_conversion<std::string> {
     // Convert the text to a std::string_view then construct a std::string.
     return std::string(datum_conversion<text>::from_datum(d, ctx).operator std::string_view());
   }
+
+  static datum into_datum(const std::string &t) {
+    return datum_conversion<std::string_view>::into_datum(t);
+  }
+};
+
+template <> struct datum_conversion<const char *> {
+  static const char *from_datum(const datum &d, std::optional<memory_context> ctx) {
+    return DatumGetPointer(d);
+  }
+
+  static datum into_datum(const char *const &t) { return datum(PointerGetDatum(t)); }
 };
 
 template <typename T> struct datum_conversion<T, std::enable_if_t<expanded_varlena_type<T>>> {
   static T from_datum(const datum &d, std::optional<memory_context> ctx) { return {d, ctx}; }
+
+  static datum into_datum(const T &t) { return t.get_expanded_datum(); }
+};
+
+/**
+ * @brief Type identified by its name
+ *
+ * @note Once constructed, the resolved type stays the same and doesn't change during
+ *       the lifetime of the value.
+ */
+struct named_type : public type {
+  /**
+   * @brief Type identified by an unqualified name
+   *
+   * @param name unqualified type name
+   */
+  named_type(const std::string_view name) : type(::TypenameGetTypid(name.data())) {}
+  /**
+   * @brief Type identified by a qualified name
+   *
+   * @param schema schema name
+   * @param name type name
+   */
+  named_type(const std::string_view schema, const std::string_view name)
+      : type(([&]() {
+          cppgres::oid nsoid = ffi_guarded(::LookupExplicitNamespace)(schema.data(), false);
+          cppgres::oid oid = InvalidOid;
+          if (OidIsValid(nsoid)) {
+            oid = (*syscache<Form_pg_type, const char *, cppgres::oid>(
+                       TYPENAMENSP, std::string(name).c_str(), nsoid))
+                      .oid;
+          }
+          return oid;
+        })()) {}
 };
 
 } // namespace cppgres

--- a/tests/datum.h
+++ b/tests/datum.h
@@ -94,13 +94,14 @@ add_test(varlena_text_from_strings, ([](test_case &) {
            bool result = true;
 
            {
-             auto d = cppgres::into_datum(std::string_view("test"));
+             auto d =
+                 cppgres::datum_conversion<std::string_view>::into_datum(std::string_view("test"));
              auto str = cppgres::datum_conversion<std::string_view>::from_datum(d, std::nullopt);
              result = result && _assert(str == "test");
            }
 
            {
-             auto d = cppgres::into_datum(std::string("test"));
+             auto d = cppgres::datum_conversion<std::string>::into_datum(std::string("test"));
              auto str = cppgres::datum_conversion<std::string_view>::from_datum(d, std::nullopt);
              result = result && _assert(str == "test");
            }

--- a/tests/spi.h
+++ b/tests/spi.h
@@ -38,6 +38,21 @@ add_test(spi_single, ([](test_case &) {
            return result;
          }));
 
+add_test(spi_plural_tuple, ([](test_case &) {
+           bool result = true;
+           cppgres::spi_executor spi;
+           auto res = spi.query<std::tuple<int64_t, int64_t>>(
+               "select $1 + i, i from generate_series(1,100) i", static_cast<int64_t>(1LL));
+
+           int i = 0;
+           for (auto &re : res) {
+             i++;
+             result = result && _assert(std::get<0>(re) == i + 1);
+             result = result && _assert(std::get<1>(re) == i);
+           }
+           return result;
+         }));
+
 add_test(spi_pfr, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -26,6 +26,7 @@ PG_MODULE_MAGIC;
 #include "memory_context.h"
 #include "spi.h"
 #include "srf.h"
+#include "type.h"
 #include "xact.h"
 
 test_case::test_case(std::string_view name, bool (*function)(test_case &c)) : function(function) {

--- a/tests/type.h
+++ b/tests/type.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "tests.h"
+
+struct my_custom_type {
+  std::string s;
+  int reserved;
+};
+
+namespace cppgres {
+template <> struct type_traits<::my_custom_type> {
+  static bool is(type &t) { return t == type_for(); }
+  static type type_for() { return cppgres::named_type("custom_type"); }
+};
+template <> struct datum_conversion<::my_custom_type> {
+  static ::my_custom_type from_datum(const datum &d, std::optional<memory_context> ctx) {
+    std::string s(datum_conversion<text>::from_datum(d, ctx).operator std::string_view());
+    return {.s = s};
+  }
+  static datum into_datum(const ::my_custom_type &t) {
+    return cppgres::datum_conversion<std::string_view>::into_datum(t.s);
+  }
+};
+
+} // namespace cppgres
+
+namespace tests {
+
+add_test(type_name_smoke, [](test_case &) {
+  auto ty = cppgres::type_traits<std::string_view>::type_for();
+  return _assert(ty.name() == "text") && _assert(ty.name(true) == "pg_catalog.text");
+});
+
+add_test(named_type, [](test_case &) {
+  bool result = true;
+  auto ty1 = cppgres::named_type("text");
+  result = result && _assert(ty1.name(true) == "pg_catalog.text");
+  auto ty2 = cppgres::named_type("pg_catalog", "text");
+  result = result && _assert(ty2.name(true) == "pg_catalog.text");
+  return result;
+});
+
+postgres_function(custom_type_fun, ([](my_custom_type t) {
+                    my_custom_type t1 = t;
+                    std::reverse(t1.s.begin(), t1.s.end());
+                    return t1;
+                  }));
+
+add_test(
+    custom_type, ([](test_case &) {
+      bool result = true;
+
+      cppgres::spi_executor spi;
+      spi.execute("create domain custom_type as text");
+      spi.execute(std::format(
+          "create function custom_type_fun(custom_type) returns custom_type language c as '{}'",
+          get_library_name()));
+
+      {
+        auto val = spi.query<my_custom_type>("select custom_type_fun('test')");
+        result = result && _assert(val.begin()[0].s == "tset");
+      }
+
+      {
+        auto val = spi.query<std::tuple<my_custom_type>>("select custom_type_fun('test')");
+        result = result && _assert(std::get<0>(val.begin()[0]).s == "tset");
+      }
+
+      {
+        auto val = spi.query<std::tuple<my_custom_type, my_custom_type>>(
+            "select custom_type_fun('test'), custom_type_fun('hi')");
+        result = result && _assert(std::get<0>(val.begin()[0]).s == "tset");
+        result = result && _assert(std::get<1>(val.begin()[0]).s == "ih");
+      }
+
+      return result;
+    }));
+
+} // namespace tests


### PR DESCRIPTION
Solution: support convertible types explicitly

The defining test case is to implement `type_traits`. This required the introduction of `named_type` type to be able to find the type of interest. Combined into/from conversion in this trait.

Importantly, handled the case of a conflict with a PFR-derived tuples. If a type is convertible from nullable datum, and is the only attribute, it is not considered as a PFR tuple.

Implemented basic syscache lookup.

Fixed up error reporting.