### PR TITLE
Set minimum version for cmake to 3.22 to work with ubuntu 22.04 LTS cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.22)
 project(cppgres)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/cmake/FindPostgres.cmake
+++ b/cmake/FindPostgres.cmake
@@ -173,6 +173,18 @@ if(NOT DEFINED PG_CONFIG)
             set(ENV{CFLAGS} "$ENV{CFLAGS} ${CMAKE_C_FLAGS_RELEASE}")
         endif()
 
+        # Ensure CC env var is not set
+        if ("${CMAKE_VERSION}" VERSION_LESS "3.24")
+            unset(ENV{CC})
+            unset(ENV{CXX})
+        else ()
+            # FIXME: this shouldn't be required. Setting CMP0132 worked without the if block,
+            # but doesn't seem to come into effect now
+            unset(ENV{CC})
+            unset(ENV{CXX})
+            cmake_policy(SET CMP0132 NEW)
+        endif ()
+
         execute_process(
                 COMMAND bash -c "./configure ${extra_configure_args} --prefix \"${PGDIR_VERSION}/build\" --without-icu --with-ssl=openssl"
                 WORKING_DIRECTORY "${PGDIR_VERSION}/postgresql-${PGVER_ALIAS}"

--- a/src/cppgres/function.hpp
+++ b/src/cppgres/function.hpp
@@ -14,14 +14,15 @@
 #include <array>
 #include <complex>
 #include <iostream>
+#include <stack>
 #include <tuple>
 #include <typeinfo>
 
 namespace cppgres {
 
 template <typename T>
-concept convertible_into_nullable_datum_or_set_iterator =
-    convertible_into_nullable_datum<T> || datumable_iterator<T>;
+concept convertible_into_nullable_datum_or_set_iterator_or_void =
+    convertible_into_nullable_datum<T> || datumable_iterator<T> || std::same_as<T, void>;
 
 /**
  * @brief Function that operates on values of Postgres types
@@ -41,8 +42,42 @@ concept datumable_function =
         std::apply(
             f,
             std::declval<typename utils::function_traits::function_traits<Func>::argument_types>())
-      } -> convertible_into_nullable_datum_or_set_iterator;
+      } -> convertible_into_nullable_datum_or_set_iterator_or_void;
     };
+
+struct current_postgres_function {
+
+  static std::optional<bool> atomic() {
+    if (!calls.empty()) {
+      auto ctx = calls.top()->context;
+      if (ctx != nullptr && IsA(ctx, CallContext)) {
+        return reinterpret_cast<::CallContext *>(ctx)->atomic;
+      }
+    }
+
+    return std::nullopt;
+  }
+
+  template <datumable_function Func> friend struct postgres_function;
+
+private:
+  struct handle {
+    ~handle() { calls.pop(); }
+
+    friend struct current_postgres_function;
+
+  private:
+    handle() {}
+  };
+
+  static handle push(::FunctionCallInfo fcinfo) {
+    calls.push(fcinfo);
+    return handle{};
+  }
+  static void pop() { calls.pop(); }
+
+  static inline std::stack<::FunctionCallInfo> calls;
+};
 
 /**
  * @brief Postgres function implemented in C++
@@ -90,18 +125,22 @@ template <datumable_function Func> struct postgres_function {
            }()),
            ...);
         }(std::make_index_sequence<utils::tuple_size_v<decltype(t)>>{});
+
+        auto call_handle = current_postgres_function::push(fc);
+
         if constexpr (datumable_iterator<return_type>) {
           // TODO: For now, let's assume materialized model
           auto rsinfo = reinterpret_cast<::ReturnSetInfo *>(fc->resultinfo);
           if (rsinfo == nullptr) {
-            report(ERROR, "caller is not expecting a set");
+            throw std::runtime_error("caller is not expecting a set");
           }
           using set_value_type = set_iterator_traits<return_type>::value_type;
           constexpr auto nargs = utils::tuple_size_v<set_value_type>;
 
           auto natts = rsinfo->expectedDesc->natts;
           if (nargs != natts) {
-            report(ERROR, "expected set with %d values, got %d instead", nargs, natts);
+            throw std::runtime_error(
+                std::format("expected set with {} values, got {} instead", nargs, natts));
           }
 
           [&]<std::size_t... Is>(std::index_sequence<Is...>) {
@@ -148,13 +187,18 @@ template <datumable_function Func> struct postgres_function {
           fc->isnull = true;
           return 0;
         } else {
-          auto result = std::apply(func, t);
-          nullable_datum nd = into_nullable_datum(result);
-          if (nd.is_null()) {
-            fc->isnull = true;
+          if constexpr (std::same_as<return_type, void>) {
+            std::apply(func, t);
             return 0;
+          } else {
+            auto result = std::apply(func, t);
+            nullable_datum nd = into_nullable_datum(result);
+            if (nd.is_null()) {
+              fc->isnull = true;
+              return 0;
+            }
+            return nd;
           }
-          return nd;
         }
       } catch (const pg_exception &e) {
         error(e);

--- a/src/cppgres/set.hpp
+++ b/src/cppgres/set.hpp
@@ -7,6 +7,7 @@
 
 #include "datum.hpp"
 #include "imports.h"
+#include "types.hpp"
 
 namespace cppgres {
 

--- a/test.sh
+++ b/test.sh
@@ -24,6 +24,7 @@ cleanup() {
 
 trap cleanup ERR
 
-${_pg_bindir}/psql -v ON_ERROR_STOP=1 -h $(realpath .testdb) -d postgres -c "load '${BUILD_DIR}/libcppgres_tests.so'; do \$\$ begin if not cppgres_tests() then raise exception 'tests failed'; end if; end; \$\$;"
+${_pg_bindir}/psql -v ON_ERROR_STOP=1 -h $(realpath .testdb) -d postgres -c "load '${BUILD_DIR}/libcppgres_tests.so';"
+${_pg_bindir}/psql -v ON_ERROR_STOP=1 -h $(realpath .testdb) -d postgres -c "call cppgres_tests();"
 ${_pg_bindir}/pg_ctl -D .testdb stop
 rm -rf .testdb

--- a/tests/function.hpp
+++ b/tests/function.hpp
@@ -9,5 +9,6 @@ postgres_function(_sig1, ([] { return true; }));
 postgres_function(_sig2, ([](std::optional<bool> v) { return v; }));
 postgres_function(_sig3, ([](bool v) { return v; }));
 postgres_function(_sig4, ([](bool v, std::optional<int64_t> n) { return v && n.has_value(); }));
+postgres_function(_void_sig_fun, ([] {}));
 
 } // namespace tests

--- a/tests/srf.hpp
+++ b/tests/srf.hpp
@@ -59,8 +59,9 @@ add_test(srf_non_srf, ([](test_case &) {
            try {
              spi.query<std::tuple<int32_t, int32_t>>("select non_srf()");
            } catch (cppgres::pg_exception &e) {
-             exception_raised =
-                 _assert(std::string_view(e.message()) == "caller is not expecting a set");
+             cppgres::report(NOTICE, "%s", e.message());
+             exception_raised = _assert(std::string_view(e.message()) ==
+                                        "exception: caller is not expecting a set");
            }
            result = result && exception_raised;
            return result;
@@ -139,8 +140,8 @@ add_test(srf_non_record_non_tup, ([](test_case &) {
 add_test(srf_non_record_non_tup_type_mismatch, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;
-           auto stmt = std::format("create or replace function non_record_srf_non_tup_t() returns "
-                                   "setof text language 'c' as '{}', 'non_record_srf_non_tup'",
+           auto stmt = std::format("create or replace function non_record_srf_non_tup() returns "
+                                   "setof text language 'c' as '{}'",
                                    get_library_name());
            spi.execute(stmt);
            bool exception_raised = false;


### PR DESCRIPTION
Set minimum version for cmake to 3.22 to work with ubuntu 22.04 LTS cmake version