### PR TITLE
Problem: sometimes functions are called without type info

### DIFF
--- a/src/cppgres/imports.h
+++ b/src/cppgres/imports.h
@@ -26,6 +26,7 @@ extern "C" {
 #include <access/tsmapi.h>
 #include <catalog/namespace.h>
 #include <catalog/pg_class.h>
+#include <catalog/pg_proc.h>
 #include <catalog/pg_type.h>
 #include <commands/event_trigger.h>
 #include <executor/spi.h>

--- a/src/cppgres/syscache.hpp
+++ b/src/cppgres/syscache.hpp
@@ -13,6 +13,10 @@ template <> struct syscache_traits<Form_pg_type> {
   static constexpr ::SysCacheIdentifier cache_id = TYPEOID;
 };
 
+template <> struct syscache_traits<Form_pg_proc> {
+  static constexpr ::SysCacheIdentifier cache_id = PROCOID;
+};
+
 template <typename T>
 concept syscached = requires(T t) {
   { *t };


### PR DESCRIPTION
And that breaks our type checker – it can't make a decision whether anything's correct.

Solution: if that happens, look this information up in the syscache

There's a little bit of a caveat, it seems, with `_in` functions for types: the signature might contain just one argument but it seems Postgres is always specifying that it is calling with three arguments.