### PR TITLE
Problem: <format> availability is still choppy

### DIFF
--- a/src/cppgres.hpp
+++ b/src/cppgres.hpp
@@ -36,6 +36,33 @@
 #ifndef cppgres_hpp
 #define cppgres_hpp
 
+#if !defined(cppgres_prefer_fmt) && __has_include(<format>)
+#include <format>
+#if (defined(__clang__) && defined(_LIBCPP_HAS_NO_INCOMPLETE_FORMAT))
+#if __has_include(<fmt/core.h>)
+#define FMT_HEADER_ONLY
+#include <fmt/core.h>
+namespace cppgres::fmt {
+using ::fmt::format;
+}
+#else
+#error "Neither functional <format> nor <fmt/core.h> available"
+#endif
+#else
+namespace cppgres::fmt {
+using std::format;
+}
+#endif
+#elif __has_include(<fmt/core.h>)
+#define FMT_HEADER_ONLY
+#include <fmt/core.h>
+namespace cppgres::fmt {
+using ::fmt::format;
+}
+#else
+#error "Neither functional <format> nor <fmt/core.h> available"
+#endif
+
 #include "cppgres/datum.hpp"
 #include "cppgres/error.hpp"
 #include "cppgres/exception_impl.hpp"
@@ -55,7 +82,8 @@
  *
  * Its argument types must conform to the @ref cppgres::convertible_from_nullable_datum concept and
  * its return type must conform to the @ref cppgres::convertible_into_nullable_datum or
- * @ref cppgres::datumable_iterator concepts. This requirement is inherited from @ref cppgres::postgres_function.
+ * @ref cppgres::datumable_iterator concepts. This requirement is inherited from @ref
+ * cppgres::postgres_function.
  *
  * \arg name Name to export it under
  * \arg function C++ function or lambda

--- a/src/cppgres/datum.hpp
+++ b/src/cppgres/datum.hpp
@@ -9,7 +9,6 @@
 #include "memory.hpp"
 
 #include <cstdint>
-#include <format>
 #include <optional>
 #include <string>
 
@@ -141,8 +140,8 @@ T from_nullable_datum(const nullable_datum &d,
     }
   } else {
     if (d.is_null()) {
-      throw std::runtime_error(
-          std::format("datum is null and can't be coerced into {}", utils::type_name<T>()));
+      throw std::runtime_error(cppgres::fmt::format("datum is null and can't be coerced into {}",
+                                                    utils::type_name<T>()));
     }
     return datum_conversion<T>::from_datum(d, context);
   }

--- a/src/cppgres/executor.hpp
+++ b/src/cppgres/executor.hpp
@@ -211,7 +211,7 @@ struct spi_executor : public executor {
            auto t = type{.oid = oid};
            if (!type_traits<utils::tuple_element_t<Is, Ret>>::is(t)) {
              throw std::invalid_argument(
-                 std::format("invalid return type in position {} ({}), got OID {}", Is,
+                 cppgres::fmt::format("invalid return type in position {} ({}), got OID {}", Is,
                              utils::type_name<utils::tuple_element_t<Is, Ret>>(), oid));
            }
          }()),
@@ -222,7 +222,7 @@ struct spi_executor : public executor {
           // okay, this is just a type we can convert
         } else {
           throw std::runtime_error(
-              std::format("expected {} return values, got {}", utils::tuple_size_v<Ret>, natts));
+              cppgres::fmt::format("expected {} return values, got {}", utils::tuple_size_v<Ret>, natts));
         }
       }
     }
@@ -299,7 +299,7 @@ struct spi_executor : public executor {
     if (rc >= 0) {
       return SPI_processed;
     } else {
-      throw std::runtime_error(std::format("spi error"));
+      throw std::runtime_error(cppgres::fmt::format("spi error"));
     }
   }
 

--- a/src/cppgres/function.hpp
+++ b/src/cppgres/function.hpp
@@ -208,7 +208,7 @@ template <datumable_function Func> struct postgres_function {
             if (!checked) {
               if (rsinfo->expectedDesc != nullptr && nargs != natts) {
                 throw std::runtime_error(
-                    std::format("expected record with {} value{}, got {} instead", nargs,
+                    cppgres::fmt::format("expected record with {} value{}, got {} instead", nargs,
                                 nargs == 1 ? "" : "s", natts));
               }
               if (rsinfo->expectedDesc != nullptr &&
@@ -229,7 +229,7 @@ template <datumable_function Func> struct postgres_function {
           auto natts = rsinfo->expectedDesc->natts;
 
           if (nargs != natts) {
-            throw std::runtime_error(std::format("expected set with {} value{}, got {} instead",
+            throw std::runtime_error(cppgres::fmt::format("expected set with {} value{}, got {} instead",
                                                  nargs, nargs == 1 ? "" : "s", natts));
           }
 
@@ -240,7 +240,7 @@ template <datumable_function Func> struct postgres_function {
                using typ = utils::tuple_element_t<Is, set_value_type>;
                if (!type_traits<typ>::is(t)) {
                  throw std::invalid_argument(
-                     std::format("invalid type in record's position {} ({}), got OID {}", Is,
+                     cppgres::fmt::format("invalid type in record's position {} ({}), got OID {}", Is,
                                  utils::type_name<typ>(), oid));
                }
              }()),

--- a/src/cppgres/record.hpp
+++ b/src/cppgres/record.hpp
@@ -195,7 +195,7 @@ struct tuple_descriptor {
 private:
   inline void check_bounds(int n) const {
     if (n + 1 > tupdesc->natts || n < 0) {
-      throw std::out_of_range(std::format(
+      throw std::out_of_range(cppgres::fmt::format(
           "attribute index {} is out of bounds for the tuple descriptor with the size of {}", n,
           tupdesc->natts));
     }
@@ -327,7 +327,7 @@ struct record {
         return get_attribute(i);
       }
     }
-    throw std::out_of_range(std::format("no attribute by the name of {}", name));
+    throw std::out_of_range(cppgres::fmt::format("no attribute by the name of {}", name));
   }
 
   /**
@@ -355,7 +355,7 @@ struct record {
 private:
   inline void check_bounds(int n) const {
     if (n + 1 > attributes() || n < 0) {
-      throw std::out_of_range(std::format(
+      throw std::out_of_range(cppgres::fmt::format(
           "attribute index {} is out of bounds for record with the size of {}", n, attributes()));
     }
   }

--- a/tests/errors.hpp
+++ b/tests/errors.hpp
@@ -20,7 +20,7 @@ postgres_function(raise_exception,
 add_test(exception_to_error, ([](test_case &) {
            bool result = false;
            cppgres::spi_executor spi;
-           auto stmt = std::format(
+           auto stmt = cppgres::fmt::format(
                "create or replace function raise_exception() returns bool language 'c' as '{}'",
                get_library_name());
            spi.execute(stmt);
@@ -42,7 +42,7 @@ postgres_function(produce_error, ([]() {
 add_test(handle_produced_error, ([](test_case &) {
            bool result = false;
            cppgres::spi_executor spi;
-           auto stmt = std::format(
+           auto stmt = cppgres::fmt::format(
                "create or replace function produce_error() returns bool language 'c' as '{}'",
                get_library_name());
            spi.execute(stmt);

--- a/tests/function.hpp
+++ b/tests/function.hpp
@@ -19,9 +19,9 @@ add_test(cstring_fun_test, ([](test_case &) {
 
            cppgres::spi_executor spi;
            spi.execute(
-               std::format("create function cstring_fun(cstring) returns text language c as '{}'",
+               cppgres::fmt::format("create function cstring_fun(cstring) returns text language c as '{}'",
                            get_library_name()));
-           spi.execute(std::format(
+           spi.execute(cppgres::fmt::format(
                "create function to_cstring_fun(text) returns cstring language c as '{}'",
                get_library_name()));
 
@@ -46,7 +46,7 @@ postgres_function(infer, ([](std::string_view s) { return s; }));
 add_test(syscache_type_inference, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;
-           spi.execute(std::format("create function infer(text) returns text language c as '{}'",
+           spi.execute(cppgres::fmt::format("create function infer(text) returns text language c as '{}'",
                                    get_library_name()));
            auto func_oid = spi.query<cppgres::oid>("select 'infer'::regproc").begin()[0];
            auto v = cppgres::datum_conversion<std::string_view>::from_datum(
@@ -67,7 +67,7 @@ add_test(syscache_type_inference_priority, ([](test_case &) {
            // We are effectively simulating this here.
            bool result = true;
            cppgres::spi_executor spi;
-           spi.execute(std::format("create function infer(text) returns text language c as '{}'",
+           spi.execute(cppgres::fmt::format("create function infer(text) returns text language c as '{}'",
                                    get_library_name()));
            auto func_oid = spi.query<cppgres::oid>("select 'infer'::regproc").begin()[0];
            auto v = cppgres::datum_conversion<std::string_view>::from_datum(
@@ -84,7 +84,7 @@ add_test(enforce_return_type, ([](test_case &) {
            cppgres::spi_executor spi;
 
            bool exception_raised = false;
-           spi.execute(std::format("create function _sig1() returns int language c as '{}'",
+           spi.execute(cppgres::fmt::format("create function _sig1() returns int language c as '{}'",
                                    get_library_name()));
            {
              cppgres::internal_subtransaction xact(false);

--- a/tests/record.hpp
+++ b/tests/record.hpp
@@ -18,8 +18,9 @@ add_test(record_fun, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;
            spi.execute("create type person as (name text, position text)");
-           spi.execute(std::format("create function record_fun(record) returns table(name text, "
-                                   "type text) language 'c' as '{}'",
+           spi.execute(
+               cppgres::fmt::format("create function record_fun(record) returns table(name text, "
+                                    "type text) language 'c' as '{}'",
                                    get_library_name()));
 
            struct tab {
@@ -82,7 +83,7 @@ postgres_function(record_defining_fun, ([]() {
 add_test(record_defining, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;
-           spi.execute(std::format(
+           spi.execute(cppgres::fmt::format(
                "create function record_defining_fun() returns setof record language 'c' as '{}'",
                get_library_name()));
 

--- a/tests/srf.hpp
+++ b/tests/srf.hpp
@@ -28,7 +28,7 @@ postgres_function(srf, ([]() {
 add_test(srf, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;
-           auto stmt = std::format(
+           auto stmt = cppgres::fmt::format(
                "create or replace function srf() returns table (a int, b int) language 'c' as '{}'",
                get_library_name());
            spi.execute(stmt);
@@ -47,7 +47,7 @@ add_test(
     srf_pfr, ([](test_case &) {
       bool result = true;
       cppgres::spi_executor spi;
-      auto stmt = std::format(
+      auto stmt = cppgres::fmt::format(
           "create or replace function srf_pfr() returns table (a int, b int) language 'c' as '{}'",
           get_library_name());
       spi.execute(stmt);
@@ -59,7 +59,7 @@ add_test(
 add_test(srf_non_srf, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;
-           auto stmt = std::format(
+           auto stmt = cppgres::fmt::format(
                "create or replace function non_srf() returns int language 'c' as '{}', 'srf'",
                get_library_name());
            spi.execute(stmt);
@@ -78,8 +78,9 @@ add_test(srf_non_srf, ([](test_case &) {
 add_test(srf_mismatch_size, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;
-           auto stmt = std::format("create or replace function srf_mismatch_size() returns table "
-                                   "(a int) language 'c' as '{}', 'srf'",
+           auto stmt =
+               cppgres::fmt::format("create or replace function srf_mismatch_size() returns table "
+                                    "(a int) language 'c' as '{}', 'srf'",
                                    get_library_name());
            spi.execute(stmt);
            bool exception_raised = false;
@@ -96,8 +97,9 @@ add_test(srf_mismatch_size, ([](test_case &) {
 add_test(srf_mismatch_types, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;
-           auto stmt = std::format("create or replace function srf_mismatch_types() returns table "
-                                   "(a int, b text) language 'c' as '{}', 'srf'",
+           auto stmt =
+               cppgres::fmt::format("create or replace function srf_mismatch_types() returns table "
+                                    "(a int, b text) language 'c' as '{}', 'srf'",
                                    get_library_name());
            spi.execute(stmt);
            bool exception_raised = false;
@@ -119,7 +121,7 @@ postgres_function(non_record_srf, ([]() {
 add_test(srf_non_record, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;
-           auto stmt = std::format(
+           auto stmt = cppgres::fmt::format(
                "create or replace function non_record_srf() returns setof int language 'c' as '{}'",
                get_library_name());
            spi.execute(stmt);
@@ -136,8 +138,9 @@ postgres_function(non_record_srf_non_tup, ([]() {
 add_test(srf_non_record_non_tup, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;
-           auto stmt = std::format("create or replace function non_record_srf_non_tup() returns "
-                                   "setof int language 'c' as '{}'",
+           auto stmt =
+               cppgres::fmt::format("create or replace function non_record_srf_non_tup() returns "
+                                    "setof int language 'c' as '{}'",
                                    get_library_name());
            spi.execute(stmt);
            auto res = spi.query<std::tuple<int32_t>>("select * from non_record_srf_non_tup()");
@@ -148,8 +151,9 @@ add_test(srf_non_record_non_tup, ([](test_case &) {
 add_test(srf_non_record_non_tup_type_mismatch, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;
-           auto stmt = std::format("create or replace function non_record_srf_non_tup() returns "
-                                   "setof text language 'c' as '{}'",
+           auto stmt =
+               cppgres::fmt::format("create or replace function non_record_srf_non_tup() returns "
+                                    "setof text language 'c' as '{}'",
                                    get_library_name());
            spi.execute(stmt);
            bool exception_raised = false;

--- a/tests/type.hpp
+++ b/tests/type.hpp
@@ -52,7 +52,7 @@ add_test(
 
       cppgres::spi_executor spi;
       spi.execute("create domain custom_type as text");
-      spi.execute(std::format(
+      spi.execute(cppgres::fmt::format(
           "create function custom_type_fun(custom_type) returns custom_type language c as '{}'",
           get_library_name()));
 


### PR DESCRIPTION
It's coming – available on some sets of platforms/compilers, but not everywhere.

Solution: allow to replace it with fmt if available