### PR TITLE
Problem: use of threads

### DIFF
--- a/src/cppgres.hpp
+++ b/src/cppgres.hpp
@@ -75,6 +75,7 @@ using ::fmt::format;
 #include "cppgres/node.hpp"
 #include "cppgres/record.hpp"
 #include "cppgres/set.hpp"
+#include "cppgres/threading.hpp"
 #include "cppgres/types.hpp"
 #include "cppgres/xact.hpp"
 

--- a/src/cppgres/threading.hpp
+++ b/src/cppgres/threading.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <future>
+#include <queue>
+#include <type_traits>
+
+#include "imports.h"
+
+#ifdef __linux__
+#include <sys/syscall.h>
+#include <unistd.h>
+#elif __APPLE__
+#include <pthread.h>
+#endif
+
+namespace cppgres {
+
+#if defined(__linux__)
+static inline bool is_main_thread() { return gettid() == getpid(); }
+#elif defined(__APPLE__)
+static inline bool is_main_thread() { return pthread_main_np() != 0; }
+#else
+#warning "is_main_thread() not implemented"
+static inline bool is_main_thread() { return false; }
+#endif
+
+/**
+ * @brief Single-threaded Postgres workload worker
+ *
+ * @warning Use extreme caution and care when handling workload – ensure the worker does not
+ *          outlive the intended lifetime – and receives no interference – that is, no other
+ *          threads should be doing any Postgres workloads while this worker is alive.
+ */
+struct worker {
+  worker() : done(false), terminated(false) {}
+
+  ~worker() { terminate(); }
+
+  void terminate() {
+    {
+      std::scoped_lock lock(mutex);
+      if (terminated)
+        return;
+      done = true;
+      cv.notify_one();
+    }
+  }
+
+  template <typename F, typename... Args>
+  auto post(F &&f, Args &&...args) -> std::future<std::invoke_result_t<F, Args...>> {
+    using ReturnType = std::invoke_result_t<F, Args...>;
+
+    auto task = std::make_shared<std::packaged_task<ReturnType()>>(
+        [f = std::move(f), ... args = std::move(args)]() { return f(args...); });
+    std::future<ReturnType> result = task->get_future();
+
+    {
+      std::scoped_lock lock(mutex);
+      tasks.emplace([task]() { (*task)(); });
+    }
+    cv.notify_one();
+    return result;
+  }
+
+  /**
+   * @brief Run the worker
+   *
+   * @throws std::runtime_error if called on a secondary thread
+   */
+  void run() {
+    if (!is_main_thread()) {
+      throw std::runtime_error("Worker can only run on main thread");
+    }
+    while (true) {
+      std::function<void()> task;
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        cv.wait(lock, [&]() { return done.load() || !tasks.empty(); });
+        if (done.load() && tasks.empty())
+          break;
+        task = std::move(tasks.front());
+        tasks.pop();
+      }
+      task();
+    }
+    terminated = true;
+  }
+
+private:
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::queue<std::function<void()>> tasks;
+  std::atomic<bool> done;
+  std::atomic<bool> terminated;
+};
+
+} // namespace cppgres

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -29,6 +29,7 @@ PG_MODULE_MAGIC;
 #include "record.hpp"
 #include "spi.hpp"
 #include "srf.hpp"
+#include "threading.hpp"
 #include "type.hpp"
 #include "xact.hpp"
 

--- a/tests/threading.hpp
+++ b/tests/threading.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "tests.hpp"
+
+namespace tests {
+
+add_test(threading, ([](test_case &) {
+           bool result = true;
+           {
+             cppgres::spi_executor spi;
+             spi.execute("create table job (i int)");
+           }
+
+           cppgres::worker wrk;
+           std::vector<std::future<int>> futures;
+           std::thread t([&]() {
+             for (int i = 0; i < 100; i++) {
+               futures.emplace_back(wrk.post(
+                   [](int i) {
+                     cppgres::spi_executor spi;
+                     auto res = spi.query<int32_t>("insert into job values ($1) returning i", i)
+                                    .begin()[0];
+                     return res;
+                   },
+                   i));
+             }
+
+             int sum = 0;
+             for (auto &future : futures) {
+               sum += future.get();
+             }
+             result = result && _assert(sum == 4950);
+
+             wrk.post([&]() { wrk.terminate(); });
+           });
+           wrk.run();
+           t.join();
+
+           return result;
+         }));
+
+add_test(threading_non_main_thread, ([](test_case &) {
+           bool result = true;
+
+           cppgres::worker wrk;
+
+           bool exception_raised = false;
+           std::thread t([&]() {
+             try {
+               wrk.run();
+             } catch (std::runtime_error &e) {
+               exception_raised = true;
+             }
+           });
+
+           t.join();
+           result = result && _assert(exception_raised);
+
+           return result;
+         }));
+
+} // namespace tests


### PR DESCRIPTION
While Postgres is (still) single-threaded, we can't properly make use of C++'s and its ecosystem's multi-threading capabilities. But it would really be helpful to.

Solution: implement a generic "worker" to handle Postgres work

This worker is intended to work in a single thread and simply processes all incoming function calls to be executed in that thread.