### PR TITLE
Problem: unable to process SPI results in a generalized fashion 

### DIFF
--- a/src/cppgres.hpp
+++ b/src/cppgres.hpp
@@ -77,6 +77,7 @@ using ::fmt::format;
 #include "cppgres/set.hpp"
 #include "cppgres/threading.hpp"
 #include "cppgres/types.hpp"
+#include "cppgres/value.hpp"
 #include "cppgres/xact.hpp"
 
 /**

--- a/src/cppgres/executor.hpp
+++ b/src/cppgres/executor.hpp
@@ -253,6 +253,8 @@ struct spi_executor : public executor {
 
     result_iterator<Ret> begin() const { return result_iterator<Ret>(table); }
     size_t end() const { return table->numvals; }
+
+    tuple_descriptor get_tuple_descriptor() const { return table->tupdesc; }
   };
 
   /**

--- a/src/cppgres/executor.hpp
+++ b/src/cppgres/executor.hpp
@@ -16,18 +16,6 @@
 
 namespace cppgres {
 
-template <typename Tuple, std::size_t... Is>
-constexpr bool all_convertible_from_nullable(std::index_sequence<Is...>) {
-  return ((convertible_from_nullable_datum<
-              utils::remove_optional_t<utils::tuple_element_t<Is, Tuple>>>) &&
-          ...);
-}
-
-template <typename T>
-concept datumable_tuple = requires {
-  typename utils::tuple_size<T>::type;
-} && all_convertible_from_nullable<T>(std::make_index_sequence<utils::tuple_size_v<T>>{});
-
 template <typename T>
 concept convertible_into_nullable_datum_and_has_a_type =
     convertible_into_nullable_datum<T> && has_a_type<T>;
@@ -66,6 +54,12 @@ private:
 
 struct executor {};
 
+template <typename T>
+concept a_vector = requires {
+  typename T::value_type;
+  typename T::allocator_type;
+} && std::same_as<T, std::vector<typename T::value_type, typename T::allocator_type>>;
+
 /**
  * @brief [SPI](https://www.postgresql.org/docs/current/spi.html) executor API
  */
@@ -79,7 +73,7 @@ struct spi_executor : public executor {
     executors.pop();
   }
 
-  template <datumable_tuple T> struct result_iterator {
+  template <typename T> struct result_iterator {
     using iterator_category = std::random_access_iterator_tag;
     using value_type = T;
     using difference_type = std::ptrdiff_t;
@@ -164,19 +158,34 @@ struct spi_executor : public executor {
           return tuples.at(n).value();
         }
       }
-      auto ret = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-        return T{([&] {
+      if constexpr (a_vector<T>) {
+        T ret;
+        for (int i = 0; i < tuptable->tupdesc->natts; i++) {
           bool isnull;
           ::Datum value =
-              ffi_guard{::SPI_getbinval}(tuptable->vals[n], tuptable->tupdesc, Is + 1, &isnull);
+              ffi_guard{::SPI_getbinval}(tuptable->vals[n], tuptable->tupdesc, i + 1, &isnull);
           ::NullableDatum datum = {.value = value, .isnull = isnull};
           auto nd = nullable_datum(datum);
-          return from_nullable_datum<utils::tuple_element_t<Is, T>>(
-              nd, ffi_guard{::SPI_gettypeid}(tuptable->tupdesc, Is + 1),
-              memory_context(tuptable->tuptabcxt));
-        }())...};
-      }(std::make_index_sequence<utils::tuple_size_v<T>>{});
-      tuples.emplace(std::next(tuples.begin(), n), std::in_place, ret);
+          ret.emplace_back(from_nullable_datum<typename T::value_type>(
+              nd, ffi_guard{::SPI_gettypeid}(tuptable->tupdesc, i + 1),
+              memory_context(tuptable->tuptabcxt)));
+        }
+        tuples.emplace(std::next(tuples.begin(), n), std::in_place, ret);
+      } else {
+        auto ret = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+          return T{([&] {
+            bool isnull;
+            ::Datum value =
+                ffi_guard{::SPI_getbinval}(tuptable->vals[n], tuptable->tupdesc, Is + 1, &isnull);
+            ::NullableDatum datum = {.value = value, .isnull = isnull};
+            auto nd = nullable_datum(datum);
+            return from_nullable_datum<utils::tuple_element_t<Is, T>>(
+                nd, ffi_guard{::SPI_gettypeid}(tuptable->tupdesc, Is + 1),
+                memory_context(tuptable->tuptabcxt));
+          }())...};
+        }(std::make_index_sequence<utils::tuple_size_v<T>>{});
+        tuples.emplace(std::next(tuples.begin(), n), std::in_place, ret);
+      }
       return tuples.at(n).value();
     }
 
@@ -202,31 +211,43 @@ struct spi_executor : public executor {
   private:
   };
 
-  template <datumable_tuple Ret> struct results {
+  template <typename Ret> struct results {
     ::SPITupleTable *table;
 
     results(::SPITupleTable *table) : table(table) {
       auto natts = table->tupdesc->natts;
-      if (natts != utils::tuple_size_v<Ret>) {
-        if (natts == 1 && convertible_from_datum<Ret>) {
-          // okay, this is just a type we can convert
-        } else {
-          throw std::runtime_error(cppgres::fmt::format("expected {} return values, got {}",
-                                                        utils::tuple_size_v<Ret>, natts));
+      if constexpr (a_vector<Ret>) {
+        for (int i = 0; i < natts; i++) {
+          auto oid = ffi_guard{::SPI_gettypeid}(table->tupdesc, i + 1);
+          auto t = type{.oid = oid};
+          if (!type_traits<typename Ret::value_type>().is(t)) {
+            throw std::invalid_argument(
+                cppgres::fmt::format("invalid return type in position {} ({}), got OID {}", i,
+                                     utils::type_name<typename Ret::value_type>(), oid));
+          }
         }
       } else {
-        [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-          (([&] {
-             auto oid = ffi_guard{::SPI_gettypeid}(table->tupdesc, Is + 1);
-             auto t = type{.oid = oid};
-             if (!type_traits<utils::tuple_element_t<Is, Ret>>().is(t)) {
-               throw std::invalid_argument(
-                   cppgres::fmt::format("invalid return type in position {} ({}), got OID {}", Is,
-                                        utils::type_name<utils::tuple_element_t<Is, Ret>>(), oid));
-             }
-           }()),
-           ...);
-        }(std::make_index_sequence<utils::tuple_size_v<Ret>>{});
+        if (natts != utils::tuple_size_v<Ret>) {
+          if (natts == 1 && convertible_from_datum<Ret>) {
+            // okay, this is just a type we can convert
+          } else {
+            throw std::runtime_error(cppgres::fmt::format("expected {} return values, got {}",
+                                                          utils::tuple_size_v<Ret>, natts));
+          }
+        } else {
+          [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            (([&] {
+               auto oid = ffi_guard{::SPI_gettypeid}(table->tupdesc, Is + 1);
+               auto t = type{.oid = oid};
+               if (!type_traits<utils::tuple_element_t<Is, Ret>>().is(t)) {
+                 throw std::invalid_argument(cppgres::fmt::format(
+                     "invalid return type in position {} ({}), got OID {}", Is,
+                     utils::type_name<utils::tuple_element_t<Is, Ret>>(), oid));
+               }
+             }()),
+             ...);
+          }(std::make_index_sequence<utils::tuple_size_v<Ret>>{});
+        }
       }
     }
 
@@ -242,7 +263,7 @@ struct spi_executor : public executor {
    * @throws std::runtime_error if there's another SPI executor in scope
    * @throws std::runtime_error if there's an SPI error
    */
-  template <datumable_tuple Ret, convertible_into_nullable_datum_and_has_a_type... Args>
+  template <typename Ret, convertible_into_nullable_datum_and_has_a_type... Args>
   results<Ret> query(std::string_view query, Args &&...args) {
     if (executors.top() != this) {
       throw std::runtime_error("not a current SPI executor");
@@ -271,7 +292,7 @@ struct spi_executor : public executor {
     return spi_plan<Args...>(ffi_guard{::SPI_prepare}(query.data(), nargs, types.data()));
   }
 
-  template <datumable_tuple Ret, convertible_into_nullable_datum... Args>
+  template <typename Ret, convertible_into_nullable_datum... Args>
   results<Ret> query(spi_plan<Args...> &query, Args &&...args) {
     if (executors.top() != this) {
       throw std::runtime_error("not a current SPI executor");

--- a/src/cppgres/record.hpp
+++ b/src/cppgres/record.hpp
@@ -373,7 +373,7 @@ static_assert(std::move_constructible<record>);
 static_assert(std::is_copy_assignable_v<record>);
 
 template <> struct datum_conversion<record> {
-  static record from_datum(const datum &d, std::optional<memory_context> ctx) {
+  static record from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
     return {reinterpret_cast<HeapTupleHeader>(ffi_guard{::pg_detoast_datum}(
                 reinterpret_cast<struct ::varlena *>(d.operator const ::Datum &()))),
             ctx.has_value() ? ctx.value() : memory_context()};
@@ -383,14 +383,14 @@ template <> struct datum_conversion<record> {
 };
 
 template <> struct type_traits<record> {
-  static bool is(const type &t) {
+  bool is(const type &t) {
     if (t.oid == RECORDOID)
       return true;
     // Check if it is a composite type and therefore can be coerced to a record
     syscache<Form_pg_type, oid> cache(t.oid);
     return (*cache).typtype == 'c';
   }
-  static constexpr type type_for() { return {.oid = RECORDOID}; }
+  constexpr type type_for() { return {.oid = RECORDOID}; }
 };
 
 } // namespace cppgres

--- a/src/cppgres/record.hpp
+++ b/src/cppgres/record.hpp
@@ -85,6 +85,11 @@ struct tuple_descriptor {
     return *TupleDescAttr(tupdesc, n);
   }
 
+  type get_type(int n) const {
+    auto &att = operator[](n);
+    return {att.atttypid};
+  }
+
   /**
    * @brief Set attribute type
    *
@@ -104,6 +109,11 @@ struct tuple_descriptor {
     att.attalign = (*typ).typalign;
     att.atttypmod = (*typ).typtypmod;
     att.attbyval = (*typ).typbyval;
+  }
+
+  std::string_view get_name(int n) {
+    auto &att = operator[](n);
+    return NameStr(att.attname);
   }
 
   /**

--- a/src/cppgres/set.hpp
+++ b/src/cppgres/set.hpp
@@ -26,7 +26,7 @@ template <datumable_iterator I> struct set_iterator_traits {
 
 template <typename I> requires datumable_iterator<I>
 struct type_traits<I> {
-  static bool is(type &t) { return t.oid == RECORDOID; }
+  bool is(type &t) { return t.oid == RECORDOID; }
 };
 
 } // namespace cppgres

--- a/src/cppgres/types.hpp
+++ b/src/cppgres/types.hpp
@@ -14,8 +14,8 @@
 namespace cppgres {
 
 template <> struct type_traits<void> {
-  static bool is(const type &t) { return t.oid == VOIDOID; }
-  static constexpr type type_for() { return type{.oid = VOIDOID}; }
+  bool is(const type &t) { return t.oid == VOIDOID; }
+  constexpr type type_for() { return type{.oid = VOIDOID}; }
 };
 
 template <> struct type_traits<oid> {
@@ -24,106 +24,138 @@ template <> struct type_traits<oid> {
 };
 
 template <typename S> struct type_traits<S, std::enable_if_t<utils::is_std_tuple<S>::value>> {
-  static bool is(const type &t) {
+  bool is(const type &t) {
     if (t.oid == RECORDOID) {
       return true;
     } else if constexpr (std::tuple_size_v<S> == 1) {
       // special case when we have a tuple of 1 matching the type
-      return type_traits<std::tuple_element_t<0, S>>::is(t);
+      return type_traits<std::tuple_element_t<0, S>>().is(t);
     }
     return false;
   }
-  static constexpr type type_for() { return type{.oid = RECORDOID}; }
+  constexpr type type_for() { return type{.oid = RECORDOID}; }
 };
 
 template <> struct type_traits<bool> {
-  static bool is(const type &t) { return t.oid == BOOLOID; }
-  static constexpr type type_for() { return type{.oid = BOOLOID}; }
+  type_traits() {}
+  type_traits(const bool &) {}
+  bool is(const type &t) { return t.oid == BOOLOID; }
+  constexpr type type_for() { return type{.oid = BOOLOID}; }
 };
 
 template <> struct type_traits<int64_t> {
-  static bool is(const type &t) { return t.oid == INT8OID || t.oid == INT4OID || t.oid == INT2OID; }
-  static constexpr type type_for() { return type{.oid = INT8OID}; }
+  type_traits() {}
+  type_traits(const int64_t &) {}
+  bool is(const type &t) { return t.oid == INT8OID || t.oid == INT4OID || t.oid == INT2OID; }
+  constexpr type type_for() { return type{.oid = INT8OID}; }
 };
 
 template <> struct type_traits<int32_t> {
-  static bool is(const type &t) { return t.oid == INT4OID || t.oid == INT2OID; }
-  static constexpr type type_for() { return type{.oid = INT4OID}; }
+  type_traits() {}
+  type_traits(const int32_t &) {}
+  bool is(const type &t) { return t.oid == INT4OID || t.oid == INT2OID; }
+  constexpr type type_for() { return type{.oid = INT4OID}; }
 };
 
 template <> struct type_traits<int16_t> {
-  static bool is(const type &t) { return t.oid == INT2OID; }
-  static constexpr type type_for() { return type{.oid = INT2OID}; }
+  type_traits() {}
+  type_traits(const int16_t &) {}
+  bool is(const type &t) { return t.oid == INT2OID; }
+  constexpr type type_for() { return type{.oid = INT2OID}; }
 };
 
 template <> struct type_traits<int8_t> {
-  static bool is(const type &t) { return t.oid == INT2OID; }
-  static constexpr type type_for() { return type{.oid = INT2OID}; }
+  type_traits() {}
+  type_traits(const int8_t &) {}
+  bool is(const type &t) { return t.oid == INT2OID; }
+  constexpr type type_for() { return type{.oid = INT2OID}; }
 };
 
 template <> struct type_traits<double> {
-  static bool is(const type &t) { return t.oid == FLOAT8OID || t.oid == FLOAT4OID; }
-  static constexpr type type_for() { return type{.oid = FLOAT8OID}; }
+  type_traits() {}
+  type_traits(const double &) {}
+  bool is(const type &t) { return t.oid == FLOAT8OID || t.oid == FLOAT4OID; }
+  constexpr type type_for() { return type{.oid = FLOAT8OID}; }
 };
 
 template <> struct type_traits<float> {
-  static bool is(const type &t) { return t.oid == FLOAT4OID; }
-  static constexpr type type_for() { return type{.oid = FLOAT4OID}; }
+  type_traits() {}
+  type_traits(const float &) {}
+  bool is(const type &t) { return t.oid == FLOAT4OID; }
+  constexpr type type_for() { return type{.oid = FLOAT4OID}; }
 };
 
 template <> struct type_traits<text> {
-  static bool is(const type &t) { return t.oid == TEXTOID; }
-  static constexpr type type_for() { return type{.oid = TEXTOID}; }
+  type_traits() {}
+  type_traits(const text &) {}
+  bool is(const type &t) { return t.oid == TEXTOID; }
+  constexpr type type_for() { return type{.oid = TEXTOID}; }
 };
 
 template <> struct type_traits<std::string_view> {
-  static bool is(const type &t) { return t.oid == TEXTOID; }
-  static constexpr type type_for() { return type{.oid = TEXTOID}; }
+  type_traits() {}
+  type_traits(const std::string_view &) {}
+  bool is(const type &t) { return t.oid == TEXTOID; }
+  constexpr type type_for() { return type{.oid = TEXTOID}; }
 };
 
 template <> struct type_traits<std::string> {
-  static bool is(const type &t) { return t.oid == TEXTOID; }
-  static constexpr type type_for() { return type{.oid = TEXTOID}; }
+  type_traits() {}
+  type_traits(const std::string &) {}
+  bool is(const type &t) { return t.oid == TEXTOID; }
+  constexpr type type_for() { return type{.oid = TEXTOID}; }
 };
 
 template <> struct type_traits<byte_array> {
-  static bool is(const type &t) { return t.oid == BYTEAOID; }
-  static constexpr type type_for() { return type{.oid = BYTEAOID}; }
+  type_traits() {}
+  type_traits(const byte_array &) {}
+  bool is(const type &t) { return t.oid == BYTEAOID; }
+  constexpr type type_for() { return type{.oid = BYTEAOID}; }
 };
 
 template <> struct type_traits<bytea> {
-  static bool is(const type &t) { return t.oid == BYTEAOID; }
-  static constexpr type type_for() { return type{.oid = BYTEAOID}; }
+  type_traits() {}
+  type_traits(const bytea &) {}
+  bool is(const type &t) { return t.oid == BYTEAOID; }
+  constexpr type type_for() { return type{.oid = BYTEAOID}; }
 };
 
 template <> struct type_traits<char *> {
-  static bool is(const type &t) { return t.oid == CSTRINGOID; }
-  static constexpr type type_for() { return type{.oid = CSTRINGOID}; }
+  type_traits() {}
+  type_traits(const char *&) {}
+  bool is(const type &t) { return t.oid == CSTRINGOID; }
+  constexpr type type_for() { return type{.oid = CSTRINGOID}; }
 };
 
 template <> struct type_traits<const char *> {
-  static bool is(const type &t) { return t.oid == CSTRINGOID; }
-  static constexpr type type_for() { return type{.oid = CSTRINGOID}; }
+  type_traits() {}
+  type_traits(const char *&) {}
+  bool is(const type &t) { return t.oid == CSTRINGOID; }
+  constexpr type type_for() { return type{.oid = CSTRINGOID}; }
 };
 
 template <std::size_t N> struct type_traits<const char[N]> {
-  static bool is(const type &t) { return t.oid == CSTRINGOID; }
-  static constexpr type type_for() { return type{.oid = CSTRINGOID}; }
+  type_traits() {}
+  type_traits(const char (&)[N]) {}
+  bool is(const type &t) { return t.oid == CSTRINGOID; }
+  constexpr type type_for() { return type{.oid = CSTRINGOID}; }
 };
 
 template <flattenable F> struct type_traits<expanded_varlena<F>> {
-  static bool is(const type &t) { return t.oid == F::type().oid; }
-  static constexpr type type_for() { return F::type(); }
+  type_traits() {}
+  type_traits(const expanded_varlena<F> &) {}
+  bool is(const type &t) { return t.oid == F::type().oid; }
+  constexpr type type_for() { return F::type(); }
 };
 
 template <> struct datum_conversion<datum> {
-  static datum from_datum(const datum &d, std::optional<memory_context>) { return d; }
+  static datum from_datum(const datum &d, oid, std::optional<memory_context>) { return d; }
 
   static datum into_datum(const datum &t) { return t; }
 };
 
 template <> struct datum_conversion<nullable_datum> {
-  static nullable_datum from_datum(const datum &d, std::optional<memory_context>) {
+  static nullable_datum from_datum(const datum &d, oid, std::optional<memory_context>) {
     return nullable_datum(d);
   }
 
@@ -131,7 +163,7 @@ template <> struct datum_conversion<nullable_datum> {
 };
 
 template <> struct datum_conversion<oid> {
-  static oid from_datum(const datum &d, std::optional<memory_context>) {
+  static oid from_datum(const datum &d, oid, std::optional<memory_context>) {
     return static_cast<oid>(d.operator const ::Datum &());
   }
 
@@ -139,7 +171,7 @@ template <> struct datum_conversion<oid> {
 };
 
 template <> struct datum_conversion<size_t> {
-  static size_t from_datum(const datum &d, std::optional<memory_context>) {
+  static size_t from_datum(const datum &d, oid, std::optional<memory_context>) {
     return static_cast<size_t>(d.operator const ::Datum &());
   }
 
@@ -147,7 +179,7 @@ template <> struct datum_conversion<size_t> {
 };
 
 template <> struct datum_conversion<int64_t> {
-  static int64_t from_datum(const datum &d, std::optional<memory_context>) {
+  static int64_t from_datum(const datum &d, oid, std::optional<memory_context>) {
     return static_cast<int64_t>(d.operator const ::Datum &());
   }
 
@@ -155,28 +187,28 @@ template <> struct datum_conversion<int64_t> {
 };
 
 template <> struct datum_conversion<int32_t> {
-  static int32_t from_datum(const datum &d, std::optional<memory_context>) {
+  static int32_t from_datum(const datum &d, oid, std::optional<memory_context>) {
     return static_cast<int32_t>(d.operator const ::Datum &());
   }
   static datum into_datum(const int32_t &t) { return datum(static_cast<::Datum>(t)); }
 };
 
 template <> struct datum_conversion<int16_t> {
-  static int16_t from_datum(const datum &d, std::optional<memory_context>) {
+  static int16_t from_datum(const datum &d, oid, std::optional<memory_context>) {
     return static_cast<int16_t>(d.operator const ::Datum &());
   }
   static datum into_datum(const int16_t &t) { return datum(static_cast<::Datum>(t)); }
 };
 
 template <> struct datum_conversion<bool> {
-  static bool from_datum(const datum &d, std::optional<memory_context>) {
+  static bool from_datum(const datum &d, oid, std::optional<memory_context>) {
     return static_cast<bool>(d.operator const ::Datum &());
   }
   static datum into_datum(const bool &t) { return datum(static_cast<::Datum>(t)); }
 };
 
 template <> struct datum_conversion<double> {
-  static double from_datum(const datum &d, std::optional<memory_context>) {
+  static double from_datum(const datum &d, oid, std::optional<memory_context>) {
     return static_cast<double>(d.operator const ::Datum &());
   }
 
@@ -184,7 +216,7 @@ template <> struct datum_conversion<double> {
 };
 
 template <> struct datum_conversion<float> {
-  static float from_datum(const datum &d, std::optional<memory_context>) {
+  static float from_datum(const datum &d, oid, std::optional<memory_context>) {
     return static_cast<float>(d.operator const ::Datum &());
   }
 
@@ -193,13 +225,15 @@ template <> struct datum_conversion<float> {
 
 // Specializations for text and bytea:
 template <> struct datum_conversion<text> {
-  static text from_datum(const datum &d, std::optional<memory_context> ctx) { return text{d, ctx}; }
+  static text from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
+    return text{d, ctx};
+  }
 
   static datum into_datum(const text &t) { return t.get_datum(); }
 };
 
 template <> struct datum_conversion<bytea> {
-  static bytea from_datum(const datum &d, std::optional<memory_context> ctx) {
+  static bytea from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
     return bytea{d, ctx};
   }
 
@@ -207,7 +241,7 @@ template <> struct datum_conversion<bytea> {
 };
 
 template <> struct datum_conversion<byte_array> {
-  static byte_array from_datum(const datum &d, std::optional<memory_context> ctx) {
+  static byte_array from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
     return bytea{d, ctx};
   }
 
@@ -222,8 +256,8 @@ template <> struct datum_conversion<byte_array> {
 // Specializations for std::string_view and std::string.
 // Here we re-use the conversion for text.
 template <> struct datum_conversion<std::string_view> {
-  static std::string_view from_datum(const datum &d, std::optional<memory_context> ctx) {
-    return datum_conversion<text>::from_datum(d, ctx);
+  static std::string_view from_datum(const datum &d, oid oid, std::optional<memory_context> ctx) {
+    return datum_conversion<text>::from_datum(d, oid, ctx);
   }
 
   static datum into_datum(const std::string_view &t) {
@@ -236,9 +270,9 @@ template <> struct datum_conversion<std::string_view> {
 };
 
 template <> struct datum_conversion<std::string> {
-  static std::string from_datum(const datum &d, std::optional<memory_context> ctx) {
+  static std::string from_datum(const datum &d, oid oid, std::optional<memory_context> ctx) {
     // Convert the text to a std::string_view then construct a std::string.
-    return std::string(datum_conversion<text>::from_datum(d, ctx).operator std::string_view());
+    return std::string(datum_conversion<text>::from_datum(d, oid, ctx).operator std::string_view());
   }
 
   static datum into_datum(const std::string &t) {
@@ -247,7 +281,7 @@ template <> struct datum_conversion<std::string> {
 };
 
 template <> struct datum_conversion<const char *> {
-  static const char *from_datum(const datum &d, std::optional<memory_context> ctx) {
+  static const char *from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
     return DatumGetPointer(d);
   }
 
@@ -255,7 +289,7 @@ template <> struct datum_conversion<const char *> {
 };
 
 template <std::size_t N> struct datum_conversion<char[N]> {
-  static const char *from_datum(const datum &d, std::optional<memory_context> ctx) {
+  static const char *from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
     return DatumGetPointer(d);
   }
 
@@ -263,7 +297,7 @@ template <std::size_t N> struct datum_conversion<char[N]> {
 };
 
 template <typename T> struct datum_conversion<T, std::enable_if_t<expanded_varlena_type<T>>> {
-  static T from_datum(const datum &d, std::optional<memory_context> ctx) { return {d, ctx}; }
+  static T from_datum(const datum &d, oid, std::optional<memory_context> ctx) { return {d, ctx}; }
 
   static datum into_datum(const T &t) { return t.get_expanded_datum(); }
 };

--- a/src/cppgres/value.hpp
+++ b/src/cppgres/value.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "datum.hpp"
+#include "type.hpp"
+
+namespace cppgres {
+
+struct value {
+
+  value(nullable_datum &&datum, type &&type) : datum_(datum), type_(type) {}
+
+  const type &get_type() const { return type_; }
+
+  const nullable_datum &get_nullable_datum() const { return datum_; };
+
+private:
+  nullable_datum datum_;
+  type type_;
+};
+
+template <> struct datum_conversion<value> {
+  static value from_datum(const datum &d, oid oid, std::optional<memory_context>) {
+    return {nullable_datum(d), type{.oid = oid}};
+  }
+
+  static datum into_datum(const value &t) { return t.get_nullable_datum(); }
+};
+
+template <> struct type_traits<value> {
+  type_traits() : value_(std::nullopt) {}
+  type_traits(value &value) : value_(std::optional(std::ref(value))) {}
+  bool is(const type &t) { return !value_.has_value() || (*value_).get().get_type() == t; }
+  constexpr type type_for() {
+    if (value_.has_value()) {
+      return (*value_).get().get_type();
+    }
+    throw std::runtime_error("can't determine type for an uninitialized value");
+  }
+
+private:
+  std::optional<std::reference_wrapper<value>> value_;
+};
+
+} // namespace cppgres

--- a/tests/bgw.hpp
+++ b/tests/bgw.hpp
@@ -7,7 +7,7 @@ namespace tests {
 extern "C" void test_bgw(::Datum arg);
 extern "C" inline void test_bgw(::Datum arg) {
   cppgres::exception_guard([](auto arg) {
-    auto db_oid = cppgres::from_nullable_datum<cppgres::oid>(cppgres::nullable_datum(arg));
+    auto db_oid = cppgres::from_nullable_datum<cppgres::oid>(cppgres::nullable_datum(arg), OIDOID);
     auto bgw = cppgres::current_background_worker();
     bgw.connect(db_oid, std::nullopt, cppgres::background_worker_bypass_allow_connection());
     bgw.unblock_signals();

--- a/tests/function.hpp
+++ b/tests/function.hpp
@@ -52,7 +52,7 @@ add_test(syscache_type_inference, ([](test_case &) {
            auto v = cppgres::datum_conversion<std::string_view>::from_datum(
                cppgres::datum(cppgres::ffi_guard{::OidFunctionCall1Coll}(
                    func_oid, 0, PointerGetDatum(::cstring_to_text("test")))),
-               cppgres::memory_context());
+               TEXTOID, cppgres::memory_context());
            result = result && _assert(v == "test");
            return result;
          }));
@@ -73,7 +73,7 @@ add_test(syscache_type_inference_priority, ([](test_case &) {
            auto v = cppgres::datum_conversion<std::string_view>::from_datum(
                cppgres::datum(cppgres::ffi_guard{::OidFunctionCall2Coll}(
                    func_oid, 0, PointerGetDatum(::cstring_to_text("test")), cppgres::datum(0))),
-               cppgres::memory_context());
+               TEXTOID, cppgres::memory_context());
            result = result && _assert(v == "test");
            return result;
          }));

--- a/tests/record.hpp
+++ b/tests/record.hpp
@@ -53,18 +53,18 @@ add_test(record_test, ([](test_case &) {
              result = result && _assert(it[0].attribute_name(0) == "name");
              result = result && _assert(it[0].attribute_name(1) == "position");
              result = result && _assert(cppgres::from_nullable_datum<std::string_view>(
-                                            it[0].get_attribute(0)) == "Joe");
+                                            it[0].get_attribute(0), TEXTOID) == "Joe");
              result =
-                 result &&
-                 _assert(cppgres::from_nullable_datum<std::string_view>(it[0]["name"]) == "Joe");
-             result = result &&
-                      _assert(cppgres::from_nullable_datum<std::string_view>(it[0][0]) == "Joe");
+                 result && _assert(cppgres::from_nullable_datum<std::string_view>(
+                                            it[0]["name"], TEXTOID) == "Joe");
              result = result && _assert(cppgres::from_nullable_datum<std::string_view>(
-                                            it[0].get_attribute(1)) == "Manager");
+                                            it[0][0], TEXTOID) == "Joe");
              result = result && _assert(cppgres::from_nullable_datum<std::string_view>(
-                                            it[0]["position"]) == "Manager");
-             result = result && _assert(cppgres::from_nullable_datum<std::string_view>(it[0][1]) ==
-                                        "Manager");
+                                            it[0].get_attribute(1), TEXTOID) == "Manager");
+             result = result && _assert(cppgres::from_nullable_datum<std::string_view>(
+                                            it[0]["position"], TEXTOID) == "Manager");
+             result = result && _assert(cppgres::from_nullable_datum<std::string_view>(
+                                            it[0][1], TEXTOID) == "Manager");
            }
 
            return result;

--- a/tests/spi.hpp
+++ b/tests/spi.hpp
@@ -416,4 +416,87 @@ add_test(spi_tupdesc_access, ([](test_case &) {
            return result;
          }));
 
+add_test(spi_readonly, ([](test_case &) {
+           bool result = true;
+
+           cppgres::spi_executor spi;
+           spi.execute("create table q (i int)");
+
+           bool exception_raised = false;
+
+           try {
+             spi.query<int>("insert into q default values returning i",
+                            cppgres::spi_executor::options(true));
+           } catch (...) {
+             exception_raised = true;
+           }
+
+           result = result && _assert(exception_raised);
+
+           return result;
+         }));
+
+add_test(spi_execute_readonly, ([](test_case &) {
+           bool result = true;
+
+           cppgres::spi_executor spi;
+
+           bool exception_raised = false;
+
+           try {
+             spi.execute("create table q (i int)", cppgres::spi_executor::options(true));
+           } catch (...) {
+             exception_raised = true;
+           }
+
+           result = result && _assert(exception_raised);
+
+           return result;
+         }));
+
+add_test(spi_plan_readonly, ([](test_case &) {
+           bool result = true;
+
+           cppgres::spi_executor spi;
+           spi.execute("create table q (i int)");
+
+           bool exception_raised = false;
+
+           auto plan = spi.plan("insert into q default values returning i");
+
+           try {
+             spi.query<int>(plan, cppgres::spi_executor::options(true));
+           } catch (...) {
+             exception_raised = true;
+           }
+
+           result = result && _assert(exception_raised);
+
+           return result;
+         }));
+
+add_test(spi_count, ([](test_case &) {
+           bool result = true;
+
+           cppgres::spi_executor spi;
+           auto res = spi.query<int>("select i from generate_series(1,10) i",
+                                     cppgres::spi_executor::options(2));
+
+           result = result && _assert(res.count() == 2);
+
+           return result;
+         }));
+
+add_test(spi_plan_count, ([](test_case &) {
+           bool result = true;
+
+           cppgres::spi_executor spi;
+           auto plan = spi.plan("select i from generate_series(1,10) i");
+           auto res = spi.query<int>(plan, cppgres::spi_executor::options(2));
+
+           result = result && _assert(res.count() == 2);
+
+           return result;
+         }));
+
 } // namespace tests

--- a/tests/spi.hpp
+++ b/tests/spi.hpp
@@ -400,4 +400,20 @@ add_test(spi_value_type, ([](test_case &) {
            return result;
          }));
 
+add_test(spi_tupdesc_access, ([](test_case &) {
+           bool result = true;
+
+           cppgres::spi_executor spi;
+           auto res = spi.query<std::tuple<cppgres::value, cppgres::value>>(
+               "select 1 as a, 'a'::text as b");
+
+           auto td = res.get_tuple_descriptor();
+           result = result && _assert(td.get_name(0) == "a");
+           result = result && _assert(td.get_type(0).oid == INT4OID);
+           result = result && _assert(td.get_name(1) == "b");
+           result = result && _assert(td.get_type(1).oid == TEXTOID);
+
+           return result;
+         }));
+
 } // namespace tests

--- a/tests/srf.hpp
+++ b/tests/srf.hpp
@@ -12,8 +12,8 @@ struct srf_pfr_res {
 
 namespace cppgres {
 template <> struct type_traits<srf_pfr_res> {
-  static bool is(const type &t) { return t.oid == RECORDOID; }
-  static constexpr type type_for() { return type{.oid = RECORDOID}; }
+  bool is(const type &t) { return t.oid == RECORDOID; }
+  constexpr type type_for() { return type{.oid = RECORDOID}; }
 };
 
 } // namespace cppgres


### PR DESCRIPTION
Currently, spi_executor results work well when the data's shape is known: it can be mapped to a tuple, a struct, or a single value.

However, if we don't know much about the query, we can't get the results in a generalized way.

Solution: devise a type system for generalized value and metadata holding