### PR TITLE
Problem: spi_executors result don't enforce return types

### DIFF
--- a/src/cppgres/bgw.hpp
+++ b/src/cppgres/bgw.hpp
@@ -265,7 +265,7 @@ struct current_background_worker : public background_worker {
       std::conjunction_v<std::is_base_of<background_worker_database_conection_flag, Flags>...>)
   {
     ffi_guard{::BackgroundWorkerInitializeConnectionByOid}(
-        db, user.has_value() ? user.value() : InvalidOid, (flags.flag() | ... | 0));
+        db, user.has_value() ? user.value() : oid(InvalidOid), (flags.flag() | ... | 0));
   }
 };
 

--- a/src/cppgres/datum.hpp
+++ b/src/cppgres/datum.hpp
@@ -14,7 +14,22 @@
 
 namespace cppgres {
 
-using oid = ::Oid;
+struct oid {
+  oid(::Oid oid) : oid_(oid) {}
+  oid(oid &oid) : oid_(oid.oid_) {}
+
+  bool operator==(const oid &rhs) const { return oid_ == rhs.oid_; }
+  bool operator!=(const oid &rhs) const { return !(rhs == *this); }
+
+  bool operator==(const ::Oid &rhs) const { return oid_ == rhs; }
+  bool operator!=(const ::Oid &rhs) const { return oid_ != rhs; }
+
+  operator ::Oid() const { return oid_; }
+
+private:
+  ::Oid oid_;
+};
+static_assert(sizeof(::Oid) == sizeof(oid));
 
 struct datum {
   template <typename T, typename> friend struct datum_conversion;

--- a/src/cppgres/function.hpp
+++ b/src/cppgres/function.hpp
@@ -129,7 +129,7 @@ template <datumable_function Func> struct postgres_function {
 
       if (!OidIsValid(rettype.oid)) {
         // TODO: not very efficient to look it up every time
-        syscache<Form_pg_proc, Oid> cache(fc->flinfo->fn_oid);
+        syscache<Form_pg_proc, oid> cache(fc->flinfo->fn_oid);
         rettype = type{.oid = (*cache).prorettype};
         retset = (*cache).proretset;
       }
@@ -162,7 +162,7 @@ template <datumable_function Func> struct postgres_function {
           auto typ = type{.oid = ffi_guard{::get_fn_expr_argtype}(fc->flinfo, Is)};
           if (!OidIsValid(typ.oid)) {
             // TODO: not very efficient to look it up every time
-            syscache<Form_pg_proc, Oid> cache(fc->flinfo->fn_oid);
+            syscache<Form_pg_proc, oid> cache(fc->flinfo->fn_oid);
             if ((*cache).proargtypes.dim1 > Is) {
               typ = type{.oid = (*cache).proargtypes.values[Is]};
             }

--- a/src/cppgres/record.hpp
+++ b/src/cppgres/record.hpp
@@ -383,7 +383,13 @@ template <> struct datum_conversion<record> {
 };
 
 template <> struct type_traits<record> {
-  static bool is(const type &t) { return t.oid == RECORDOID; }
+  static bool is(const type &t) {
+    if (t.oid == RECORDOID)
+      return true;
+    // Check if it is a composite type and therefore can be coerced to a record
+    syscache<Form_pg_type, oid> cache(t.oid);
+    return (*cache).typtype == 'c';
+  }
   static constexpr type type_for() { return {.oid = RECORDOID}; }
 };
 

--- a/src/cppgres/types.hpp
+++ b/src/cppgres/types.hpp
@@ -18,6 +18,11 @@ template <> struct type_traits<void> {
   static constexpr type type_for() { return type{.oid = VOIDOID}; }
 };
 
+template <> struct type_traits<oid> {
+  static bool is(const type &t) { return t.oid == OIDOID; }
+  static constexpr type type_for() { return type{.oid = OIDOID}; }
+};
+
 template <typename S> struct type_traits<S, std::enable_if_t<utils::is_std_tuple<S>::value>> {
   static bool is(const type &t) {
     if (t.oid == RECORDOID) {

--- a/tests/bgw.hpp
+++ b/tests/bgw.hpp
@@ -22,7 +22,7 @@ add_test(bgworker, ([](test_case &) {
                              .type("test_bgw")
                              .library_name(get_library_name())
                              .function_name("test_bgw")
-                             .main_arg(cppgres::into_nullable_datum(MyDatabaseId))
+                             .main_arg(cppgres::into_nullable_datum(cppgres::oid(MyDatabaseId)))
                              .flags(BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION)
                              .start_time(BgWorkerStart_RecoveryFinished);
 

--- a/tests/function.hpp
+++ b/tests/function.hpp
@@ -48,7 +48,7 @@ add_test(syscache_type_inference, ([](test_case &) {
            cppgres::spi_executor spi;
            spi.execute(cppgres::fmt::format("create function infer(text) returns text language c as '{}'",
                                    get_library_name()));
-           auto func_oid = spi.query<cppgres::oid>("select 'infer'::regproc").begin()[0];
+           auto func_oid = spi.query<cppgres::oid>("select 'infer'::regproc::oid").begin()[0];
            auto v = cppgres::datum_conversion<std::string_view>::from_datum(
                cppgres::datum(cppgres::ffi_guard{::OidFunctionCall1Coll}(
                    func_oid, 0, PointerGetDatum(::cstring_to_text("test")))),
@@ -69,7 +69,7 @@ add_test(syscache_type_inference_priority, ([](test_case &) {
            cppgres::spi_executor spi;
            spi.execute(cppgres::fmt::format("create function infer(text) returns text language c as '{}'",
                                    get_library_name()));
-           auto func_oid = spi.query<cppgres::oid>("select 'infer'::regproc").begin()[0];
+           auto func_oid = spi.query<cppgres::oid>("select 'infer'::regproc::oid").begin()[0];
            auto v = cppgres::datum_conversion<std::string_view>::from_datum(
                cppgres::datum(cppgres::ffi_guard{::OidFunctionCall2Coll}(
                    func_oid, 0, PointerGetDatum(::cstring_to_text("test")), cppgres::datum(0))),

--- a/tests/xact.hpp
+++ b/tests/xact.hpp
@@ -35,7 +35,7 @@ add_test(internal_subtransaction_commit, ([](test_case &) {
              spi.execute("insert into internal_subtransaction_commit default values");
            }
            cppgres::spi_executor spi;
-           auto res = spi.query<std::tuple<int32_t>>(
+           auto res = spi.query<std::tuple<int64_t>>(
                "select count(*) from internal_subtransaction_commit");
            result = result && _assert(std::get<0>(res.begin()[0]) == 1);
            return result;
@@ -53,7 +53,7 @@ add_test(internal_subtransaction_rollback, ([](test_case &) {
              spi.execute("insert into internal_subtransaction_rollback default values");
            }
            cppgres::spi_executor spi;
-           auto res = spi.query<std::tuple<int32_t>>(
+           auto res = spi.query<std::tuple<int64_t>>(
                "select count(*) from internal_subtransaction_rollback");
            result = result && _assert(std::get<0>(res.begin()[0]) == 0);
            return result;


### PR DESCRIPTION
It seem to have done this accidentally in some tests, but simply observing that we're iterating over `Args` to get types shows us that this is wrong.

Solution: ensure we actually iterate the return tuple types instead

This necessitated some signature changes (dropping `Args` is obvious) and promotion of `cppgres::oid` into a struct so we can implement correct conversion and type traits on it.