### PR TITLE
Problem: getting access to all syscache attributes

### DIFF
--- a/tests/syscache.hpp
+++ b/tests/syscache.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "tests.hpp"
+
+namespace tests {
+
+add_test(syscache, ([](test_case &) {
+  bool result = true;
+
+  cppgres::spi_executor spi;
+
+  spi.execute("create function test_function() returns int language sql as $$select 0$$");
+
+  auto func_oid = spi.query<cppgres::oid>("select 'test_function'::regproc::oid");
+  cppgres::syscache<Form_pg_proc, cppgres::oid> cache(func_oid.begin()[0]);
+
+  result = result && _assert(NameStr((*cache).proname) == std::string_view("test_function"));
+
+  return result;
+}));
+
+add_test(syscache_get_attribute, ([](test_case &) {
+  bool result = true;
+
+  cppgres::spi_executor spi;
+
+  spi.execute("create function test_function() returns int language sql as $$select 1$$");
+
+  auto func_oid = spi.query<cppgres::oid>("select 'test_function'::regproc::oid");
+  cppgres::syscache<Form_pg_proc, cppgres::oid> cache(func_oid.begin()[0]);
+
+  result = result && _assert(cache.get_attribute<std::string_view>(Anum_pg_proc_prosrc) == "select 1");
+
+  return result;
+}));
+} // namespace tests

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -30,6 +30,7 @@ PG_MODULE_MAGIC;
 #include "record.hpp"
 #include "spi.hpp"
 #include "srf.hpp"
+#include "syscache.hpp"
 #include "threading.hpp"
 #include "type.hpp"
 #include "xact.hpp"


### PR DESCRIPTION
`syscache` can be dereference to an underlying structure, but not all of its information is accessible through the struct, as they are only available using special routines.

Solution: add `get_attribute` method to retrieve & convert those