### PR TITLE
Problem: call info disjoining arg datums and arg types

### DIFF
--- a/src/cppgres/function.hpp
+++ b/src/cppgres/function.hpp
@@ -11,6 +11,7 @@
 #include "types.hpp"
 #include "utils/function_traits.hpp"
 #include "utils/utils.hpp"
+#include "value.hpp"
 
 #include <array>
 #include <complex>
@@ -72,6 +73,17 @@ struct function_call_info {
   auto arg_types() const {
     return std::views::iota(0, nargs()) | std::views::transform([this](int i) -> type {
              return {.oid = ffi_guard{::get_fn_expr_argtype}(info_->flinfo, i)};
+           });
+  }
+
+  /**
+   * @brief typed passed argument
+   */
+
+  auto arg_values() const {
+    return std::views::iota(0, nargs()) | std::views::transform([this](int i) -> value {
+             return value(nullable_datum(info_->args[i]),
+                          {.oid = ffi_guard{::get_fn_expr_argtype}(info_->flinfo, i)});
            });
   }
 

--- a/tests/function.hpp
+++ b/tests/function.hpp
@@ -113,6 +113,8 @@ add_test(current_postgres_function, ([](test_case &) {
            // args
            result = result && _assert((*ci).nargs() == 1);
            result = result && _assert((*ci).arg_types()[0] == cppgres::type{.oid = TEXTOID});
+           result =
+               result && _assert((*ci).arg_values()[0].get_type() == cppgres::type{.oid = TEXTOID});
 
            // return type
            result = result && _assert((*ci).return_type() == cppgres::type{.oid = BOOLOID});


### PR DESCRIPTION
In `function_call_info` it is possible either to get arg datum iterator or arg type iterator, but not both.

While this is not a problem in C++23 (due to zip views), it's extra work and is not readily available in C++20.

Solution: use `value` type to represent the joined argument and expose it through `arg_values()`.