### PR TITLE
Problem: access to heap tuple header

### DIFF
--- a/src/cppgres/executor.hpp
+++ b/src/cppgres/executor.hpp
@@ -209,6 +209,8 @@ struct spi_executor : public executor {
       return index >= other.index;
     }
 
+    operator const heap_tuple() const { return tuptable->vals[index]; }
+
   private:
   };
 

--- a/src/cppgres/heap_tuple.hpp
+++ b/src/cppgres/heap_tuple.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "imports.h"
+#include "xact.hpp"
+
+namespace cppgres {
+
+/**
+ * @brief Heap tuple convenience wrapper
+ */
+struct heap_tuple {
+
+  heap_tuple(::HeapTuple tuple) : tuple_(tuple) {}
+
+  operator ::HeapTuple() const { return tuple_; }
+
+  transaction_id xmin(bool raw = false) const {
+    return raw ? HeapTupleHeaderGetRawXmin(tuple_->t_data) : HeapTupleHeaderGetXmin(tuple_->t_data);
+  }
+
+  transaction_id xmax() const { return HeapTupleHeaderGetRawXmax(tuple_->t_data); }
+
+  transaction_id update_xid() const { return HeapTupleHeaderGetUpdateXid(tuple_->t_data); }
+
+  command_id cmin() const { return HeapTupleHeaderGetCmin(tuple_->t_data); }
+  command_id cmax() const { return HeapTupleHeaderGetCmax(tuple_->t_data); }
+
+private:
+  HeapTuple tuple_;
+};
+
+static_assert(sizeof(heap_tuple) == sizeof(::HeapTuple));
+
+} // namespace cppgres

--- a/tests/heap_tuple.hpp
+++ b/tests/heap_tuple.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "tests.hpp"
+
+extern "C" {
+#include <executor/spi_priv.h>
+}
+
+namespace tests {
+
+add_non_atomic_test(heap_tuple, ([](test_case &) {
+                      bool result = true;
+                      cppgres::transaction_id txid = cppgres::transaction_id::current();
+                      {
+                        cppgres::spi_nonatomic_executor spi;
+                        spi.execute("create table heap_tuple_1 as select 1 as i");
+                        spi.commit();
+                      }
+                      {
+                        cppgres::spi_nonatomic_executor spi;
+                        auto res =
+                            spi.query<std::vector<cppgres::value>>("select * from heap_tuple_1");
+                        auto t = res.begin();
+                        cppgres::heap_tuple ht = t;
+                        result = result && _assert(ht.xmin(true) == txid);
+                        spi.execute("update heap_tuple_1 set i = i+1");
+                        spi.commit();
+                      }
+                      {
+                        cppgres::spi_nonatomic_executor spi;
+                        auto res =
+                            spi.query<std::vector<cppgres::value>>("select * from heap_tuple_1");
+                        auto t = res.begin();
+                        cppgres::heap_tuple ht = t;
+                        result = result && _assert(ht.xmin(true) > txid);
+                      }
+                      return result;
+                    }));
+
+} // namespace tests

--- a/tests/tests.hpp
+++ b/tests/tests.hpp
@@ -6,12 +6,19 @@
 struct test_case {
   inline static std::map<std::string_view, test_case *> test_cases =
       std::map<std::string_view, test_case *>{};
-  test_case(std::string_view name, bool (*function)(test_case &c));
+  test_case(std::string_view name, bool (*function)(test_case &c), bool is_atomic = true);
   bool operator()();
+
+  bool is_atomic() const { return atomic; }
+
+protected:
   bool (*function)(test_case &c);
+  bool atomic;
 };
 
 #define add_test(name, code) static test_case t__##name(std::string_view(#name), code);
+#define add_non_atomic_test(name, code)                                                            \
+  static test_case t__##name(std::string_view(#name), code, false);
 
 #define _assert(expr)                                                                              \
   ({                                                                                               \


### PR DESCRIPTION
At times, there's a need to access heap tuple's header and its properties. For example, to get xmin, xmax, cmin, cmax.

An example: PLs (programing language handlers) often use xmin to determine if pg_proc entry has been updated to reload the cached code.

Solution: expose heap tuple in syscache and SPI
and provide a few common methods.

More methods and documentation to be added.