### PR TITLE
Problem: writing aggregates in C++

### DIFF
--- a/src/cppgres.hpp
+++ b/src/cppgres.hpp
@@ -63,6 +63,7 @@ using ::fmt::format;
 #error "Neither functional <format> nor <fmt/core.h> available"
 #endif
 
+#include "cppgres/aggregate.hpp"
 #include "cppgres/bgw.hpp"
 #include "cppgres/datum.hpp"
 #include "cppgres/error.hpp"

--- a/src/cppgres/aggregate.hpp
+++ b/src/cppgres/aggregate.hpp
@@ -1,0 +1,151 @@
+#pragma once
+
+#include "function.hpp"
+#include "imports.h"
+
+namespace cppgres {
+
+template <class T, class... Args>
+concept aggregate = requires(T t, Args &&...args) {
+  { t.update(args...) };
+};
+
+template <class T, class... Args>
+concept finalizable_aggregate = aggregate<T, Args...> && requires(T t) {
+  { t.finalize() } -> convertible_into_datum;
+};
+
+template <class T, class... Args>
+concept serializable_aggregate = aggregate<T, Args...> && requires(T t, bytea &ba) {
+  { t.serialize() } -> std::same_as<bytea>;
+  { T(ba) } -> std::same_as<T>;
+};
+
+template <class T, class... Args>
+concept combinable_aggregate = aggregate<T, Args...> && requires(T &&t, T &&t1) {
+  { T(t, t1) } -> std::same_as<T>;
+};
+
+template <class Agg, typename... InTs> datum aggregate_sfunc(value state, InTs... args) {
+
+  MemoryContext aggctx;
+  if (!ffi_guard{::AggCheckCallContext}(current_postgres_function::call_info().operator*(),
+                                        &aggctx)) {
+    report(ERROR, "not aggregate context");
+  }
+
+  if constexpr (!convertible_into_datum<Agg> && finalizable_aggregate<Agg, InTs...>) {
+    Agg *state0;
+    if (state.get_nullable_datum().is_null()) {
+      state0 = memory_context(aggctx).alloc<Agg>();
+      std::construct_at(state0);
+    } else {
+      state0 = reinterpret_cast<Agg *>(
+          from_nullable_datum<void *>(state.get_nullable_datum(), state.get_type().oid));
+    }
+
+    state0->update(args...);
+
+    return datum_conversion<void *>::into_datum(reinterpret_cast<void *>(state0));
+  } else if constexpr (convertible_into_datum<Agg>) {
+    Agg state0 = datum_conversion<Agg>::from_nullable_datum(state.get_nullable_datum(), ANYOID);
+    state0.update(args...);
+    return datum_conversion<Agg>::into_datum(state0);
+  }
+  report(ERROR, "not supported");
+  __builtin_unreachable();
+}
+
+template <class Agg, typename... InTs> nullable_datum aggregate_ffunc(value state) {
+  if constexpr (finalizable_aggregate<Agg, InTs...>) {
+    Agg *state0;
+    state0 = reinterpret_cast<Agg *>(
+        from_nullable_datum<void *>(state.get_nullable_datum(), state.get_type().oid));
+    return into_nullable_datum(state0->finalize());
+  } else {
+    report(ERROR, "this aggregate does not support final function");
+    __builtin_unreachable();
+  }
+}
+
+template <class Agg, typename... InTs> bytea aggregate_serial(value state) {
+  if constexpr (serializable_aggregate<Agg, InTs...>) {
+    if (state.get_type().oid == INTERNALOID) {
+      Agg *state0;
+      state0 = reinterpret_cast<Agg *>(
+          from_nullable_datum<void *>(state.get_nullable_datum(), state.get_type().oid));
+      bytea ba = state0->serialize();
+      return ba;
+    }
+  }
+  report(ERROR, "this aggregate does not support serialize");
+  __builtin_unreachable();
+}
+
+template <class Agg, typename... InTs> datum aggregate_deserial(bytea ba, value) {
+  if constexpr (serializable_aggregate<Agg, InTs...>) {
+    MemoryContext aggctx;
+    if (!ffi_guard{::AggCheckCallContext}(current_postgres_function::call_info().operator*(),
+                                          &aggctx)) {
+      report(ERROR, "not aggregate context");
+    }
+    Agg *state0 = memory_context(aggctx).alloc<Agg>();
+    std::construct_at(state0, ba);
+    return datum_conversion<void *>::into_datum(reinterpret_cast<void *>(state0));
+  }
+  report(ERROR, "this aggregate does not support serialize");
+  __builtin_unreachable();
+}
+
+template <class Agg, typename... InTs> datum aggregate_combine(value state, value other) {
+  MemoryContext aggctx;
+  if (!ffi_guard{::AggCheckCallContext}(current_postgres_function::call_info().operator*(),
+                                        &aggctx)) {
+    report(ERROR, "not aggregate context");
+  }
+  if constexpr (combinable_aggregate<Agg, InTs...>) {
+    if constexpr (!convertible_into_datum<Agg> && finalizable_aggregate<Agg, InTs...>) {
+      Agg *state0;
+      if (state.get_nullable_datum().is_null()) {
+        state0 = memory_context(aggctx).alloc<Agg>();
+        std::construct_at(state0);
+      } else {
+        state0 = reinterpret_cast<Agg *>(
+            from_nullable_datum<void *>(state.get_nullable_datum(), state.get_type().oid));
+      }
+
+      Agg *state1;
+      if (other.get_nullable_datum().is_null()) {
+        state1 = memory_context(aggctx).alloc<Agg>();
+        std::construct_at(state1);
+      } else {
+        state1 = reinterpret_cast<Agg *>(
+            from_nullable_datum<void *>(other.get_nullable_datum(), other.get_type().oid));
+      }
+
+      Agg *newstate = memory_context(aggctx).alloc<Agg>();
+      std::construct_at(newstate, *state0, *state1);
+
+      return datum_conversion<void *>::into_datum(reinterpret_cast<void *>(newstate));
+    } else if constexpr (convertible_into_datum<Agg>) {
+      Agg state0 = datum_conversion<Agg>::from_nullable_datum(state.get_nullable_datum(), ANYOID);
+      Agg state1 = datum_conversion<Agg>::from_nullable_datum(state.get_nullable_datum(), ANYOID);
+      return datum_conversion<Agg>::into_datum(Agg(state0, state1));
+    }
+  }
+  report(ERROR, "not supported");
+  __builtin_unreachable();
+}
+
+} // namespace cppgres
+
+#define declare_aggregate(name, typname, ...)                                                      \
+  static_assert(::cppgres::aggregate<typname, ##__VA_ARGS__>);                                     \
+  static_assert(::cppgres::convertible_into_datum<typname> ||                                      \
+                    ::cppgres::finalizable_aggregate<typname, ##__VA_ARGS__>,                   \
+                "must be convertible to datum or have finalize()");                                \
+  postgres_function(name##_sfunc, (cppgres::aggregate_sfunc<typname, ##__VA_ARGS__>));             \
+  postgres_function(name##_ffunc, (cppgres::aggregate_ffunc<typname, ##__VA_ARGS__>));             \
+  postgres_function(name##_serial, (cppgres::aggregate_serial<typname, ##__VA_ARGS__>));           \
+  postgres_function(name##_deserial, (cppgres::aggregate_deserial<typname, ##__VA_ARGS__>));       \
+  postgres_function(name##_combine, (cppgres::aggregate_combine<typname, ##__VA_ARGS__>));

--- a/src/cppgres/record.hpp
+++ b/src/cppgres/record.hpp
@@ -382,7 +382,7 @@ static_assert(std::copy_constructible<record>);
 static_assert(std::move_constructible<record>);
 static_assert(std::is_copy_assignable_v<record>);
 
-template <> struct datum_conversion<record> {
+template <> struct datum_conversion<record> : default_datum_conversion<record> {
   static record from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
     return {reinterpret_cast<HeapTupleHeader>(ffi_guard{::pg_detoast_datum}(
                 reinterpret_cast<struct ::varlena *>(d.operator const ::Datum &()))),

--- a/src/cppgres/value.hpp
+++ b/src/cppgres/value.hpp
@@ -19,6 +19,12 @@ private:
 };
 
 template <> struct datum_conversion<value> {
+
+  static value from_nullable_datum(const nullable_datum &d, oid oid,
+                                   std::optional<memory_context>) {
+    return {nullable_datum(d), type{.oid = oid}};
+  }
+
   static value from_datum(const datum &d, oid oid, std::optional<memory_context>) {
     return {nullable_datum(d), type{.oid = oid}};
   }

--- a/tests/aggregate.hpp
+++ b/tests/aggregate.hpp
@@ -1,0 +1,164 @@
+#pragma once
+
+#include <cstring>
+
+#include "tests.hpp"
+
+namespace tests {
+
+struct aggregate_test {
+  int64_t x;
+  aggregate_test() : x(0) {}
+  aggregate_test(int64_t x_) : x(x_) {}
+
+  void update(int64_t v) { x += v; }
+  void update(int64_t v, int64_t v1) { x += v + v1; }
+
+  int64_t finalize() const { return x; }
+
+  // Serialization
+
+  cppgres::bytea serialize() const {
+    std::array<std::byte, 8> bytes;
+    std::memcpy(bytes.data(), &x, sizeof(x));
+    return {bytes, cppgres::memory_context()};
+  };
+  aggregate_test(cppgres::bytea &a) {
+    std::memcpy(&x, a.operator cppgres::byte_array().data(), sizeof(x));
+  }
+
+  // Combination
+  aggregate_test(aggregate_test &self, aggregate_test &other) : x(self.x + other.x) {
+  }
+};
+
+declare_aggregate(aggregate, aggregate_test, int64_t);
+declare_aggregate(aggregate2, aggregate_test, int64_t, int64_t);
+
+struct aggregate_convertible_test {
+  int64_t x;
+  aggregate_convertible_test() : x(0) {}
+  aggregate_convertible_test(int64_t x_) : x(x_) {}
+  void update(int64_t v) { x += v; }
+};
+
+add_test(aggregate_simple, [](test_case &) {
+  bool result = true;
+  cppgres::spi_executor spi;
+  spi.execute(cppgres::fmt::format("create or replace function aggregate_sfunc(internal, int8) "
+                                   "returns internal language c as '{}'",
+                                   get_library_name()));
+  spi.execute(cppgres::fmt::format(
+      "create or replace function aggregate_ffunc(internal) returns int8 language c as '{}'",
+      get_library_name()));
+  spi.execute(
+      "create aggregate agg (int8) (sfunc = aggregate_sfunc, finalfunc = aggregate_ffunc, stype "
+      "= internal)");
+  auto res = spi.query<int64_t>("select agg(v) from (values (1), (2), (3)) as t(v)");
+  result = result && _assert(res.begin()[0] == 6);
+  return result;
+});
+
+add_test(aggregate_simple_2arg, [](test_case &) {
+  bool result = true;
+  cppgres::spi_executor spi;
+  spi.execute(
+      cppgres::fmt::format("create or replace function aggregate2_sfunc(internal, int8, int8) "
+                           "returns internal language c as '{}'",
+                           get_library_name()));
+  spi.execute(cppgres::fmt::format(
+      "create or replace function aggregate2_ffunc(internal) returns int8 language c as '{}'",
+      get_library_name()));
+  spi.execute("create aggregate agg (int8, int8) (sfunc = aggregate2_sfunc, finalfunc = "
+              "aggregate2_ffunc, stype "
+              "= internal)");
+  auto res = spi.query<int64_t>("select agg(v,v) from (values (1), (2), (3)) as t(v)");
+  result = result && _assert(res.begin()[0] == 12);
+  return result;
+});
+
+add_test(aggregate_simple_serial, [](test_case &) {
+  bool result = true;
+  cppgres::spi_executor spi;
+  spi.execute(cppgres::fmt::format("create or replace function aggregate_sfunc(internal, int8) "
+                                   "returns internal language c as '{}'",
+                                   get_library_name()));
+  spi.execute(cppgres::fmt::format(
+      "create or replace function aggregate_ffunc(internal) returns int8 language c as '{}'",
+      get_library_name()));
+  spi.execute(cppgres::fmt::format(
+      "create or replace function aggregate_serial(internal) returns bytea language c as '{}'",
+      get_library_name()));
+  spi.execute(cppgres::fmt::format("create or replace function aggregate_deserial(bytea, internal) "
+                                   "returns internal language c as '{}'",
+                                   get_library_name()));
+  spi.execute(
+      cppgres::fmt::format("create or replace function aggregate_combine(internal, internal) "
+                           "returns internal language c as '{}'",
+                           get_library_name()));
+  spi.execute(
+      "create aggregate agg (int8) (sfunc = aggregate_sfunc, finalfunc = aggregate_ffunc, stype "
+      "= internal, serialfunc = aggregate_serial, deserialfunc = aggregate_deserial, parallel = "
+      "safe, combinefunc = aggregate_combine)");
+
+  spi.execute("set max_parallel_workers_per_gather = 4");
+  spi.execute("set parallel_setup_cost = 1");
+  spi.execute("set parallel_tuple_cost = 0.01");
+
+  spi.execute("create table values as select v from generate_series(1, 1000000) v");
+
+  {
+    auto res0 = spi.query<std::string>("explain select agg(v) from values");
+
+    std::ostringstream oss;
+    for (auto s : res0) {
+      oss << s << "\n";
+    }
+    auto plan = oss.str();
+
+    result = result && _assert(plan.find("Partial Aggregate") != std::string::npos);
+  }
+
+  auto res = spi.query<int64_t>("select agg(v) from values");
+  result = result && _assert(res.begin()[0] == 500000500000);
+  return result;
+});
+
+add_test(aggregate_convertible, [](test_case &) {
+  bool result = true;
+  cppgres::spi_executor spi;
+  spi.execute(
+      cppgres::fmt::format("create or replace function aggregate_convertible_sfunc(int8, int8) "
+                           "returns int8 language c as '{}'",
+                           get_library_name()));
+  spi.execute("create aggregate agg (int8) (sfunc = aggregate_convertible_sfunc, stype = int8)");
+  auto res = spi.query<int64_t>("select agg(v) from (values (1), (2), (3)) as t(v)");
+  result = result && _assert(res.begin()[0] == 6);
+  return result;
+});
+
+}; // namespace tests
+
+namespace cppgres {
+template <> struct datum_conversion<tests::aggregate_convertible_test> {
+  static tests::aggregate_convertible_test
+  from_nullable_datum(const nullable_datum &d, const oid oid,
+                      std::optional<memory_context> context = std::nullopt) {
+    if (d.is_null()) {
+      return {};
+    } else {
+      return {datum_conversion<int64_t>::from_datum(d, oid, context)};
+    }
+  }
+
+  static tests::aggregate_convertible_test
+  from_datum(const datum &d, const oid oid, std::optional<memory_context> context = std::nullopt) {
+    return {datum_conversion<int64_t>::from_datum(d, oid, context)};
+  }
+  static datum into_datum(const tests::aggregate_convertible_test &d) {
+    return datum_conversion<int64_t>::into_datum(d.x);
+  }
+};
+} // namespace cppgres
+
+declare_aggregate(aggregate_convertible, tests::aggregate_convertible_test, int64_t);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -23,6 +23,7 @@ PG_MODULE_MAGIC;
 
 #include "tests.hpp"
 
+#include "aggregate.hpp"
 #include "backend.hpp"
 #include "bgw.hpp"
 #include "datum.hpp"

--- a/tests/type.hpp
+++ b/tests/type.hpp
@@ -12,7 +12,7 @@ template <> struct type_traits<::my_custom_type> {
   bool is(type &t) { return t == type_for(); }
   type type_for() { return cppgres::named_type("custom_type"); }
 };
-template <> struct datum_conversion<::my_custom_type> {
+template <> struct datum_conversion<::my_custom_type> : default_datum_conversion<::my_custom_type> {
   static ::my_custom_type from_datum(const datum &d, oid oid, std::optional<memory_context> ctx) {
     std::string s(datum_conversion<text>::from_datum(d, oid, ctx).operator std::string_view());
     return {.s = s};


### PR DESCRIPTION
It's possible but involves a lot of manual work. The promise of this library, however, is to make things trivial.

Solution: design a conceptual API for it

It still misses a few things, like moving-aggregate mode, final func extra and so on.

This is a relatively large change that introduces a change to `datum_conversion` trait, adding `from_nullable_datum`, and introducing `default_datum_conversion` that removes some of the boilerplate. This is a good change as it vastly simplified `from_nullable_datum`, removing a lot of special-casing.