### PR TITLE
Problem: incorrect float values

### DIFF
--- a/src/cppgres/types.hpp
+++ b/src/cppgres/types.hpp
@@ -232,18 +232,18 @@ template <> struct datum_conversion<bool> : default_datum_conversion<bool> {
 
 template <> struct datum_conversion<double> : default_datum_conversion<double> {
   static double from_datum(const datum &d, oid, std::optional<memory_context>) {
-    return static_cast<double>(d.operator const ::Datum &());
+    return DatumGetFloat8(d.operator const ::Datum &());
   }
 
-  static datum into_datum(const double &t) { return datum(static_cast<::Datum>(t)); }
+  static datum into_datum(const double &t) { return datum(Float8GetDatum(t)); }
 };
 
 template <> struct datum_conversion<float> : default_datum_conversion<float> {
   static float from_datum(const datum &d, oid, std::optional<memory_context>) {
-    return static_cast<float>(d.operator const ::Datum &());
+    return DatumGetFloat4(d.operator const ::Datum &());
   }
 
-  static datum into_datum(const float &t) { return datum(static_cast<::Datum>(t)); }
+  static datum into_datum(const float &t) { return datum(Float4GetDatum(t)); }
 };
 
 // Specializations for text and bytea:

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -38,6 +38,7 @@ PG_MODULE_MAGIC;
 #include "syscache.hpp"
 #include "threading.hpp"
 #include "type.hpp"
+#include "typeconv.hpp"
 #include "xact.hpp"
 
 test_case::test_case(std::string_view name, bool (*function)(test_case &c), bool is_atomic)

--- a/tests/typeconv.hpp
+++ b/tests/typeconv.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "tests.hpp"
+
+namespace tests {
+
+add_test(from_float, [](test_case &) {
+  bool result = true;
+  float val = 131073.0;
+  Datum d = Float4GetDatum(val);
+  result = result && _assert(cppgres::into_nullable_datum(val) == d);
+  return result;
+});
+
+add_test(to_float, [](test_case &) {
+  bool result = true;
+  float val = 131073.0;
+  Datum d = Float4GetDatum(val);
+  result = result && _assert(cppgres::from_nullable_datum<float>(cppgres::nullable_datum(d), FLOAT4OID) == val);
+  return result;
+});
+
+add_test(from_double, [](test_case &) {
+  bool result = true;
+  double val = 8796093022209.0;
+  Datum d = Float8GetDatum(val);
+  result = result && _assert(cppgres::into_nullable_datum(val) == d);
+  return result;
+});
+
+add_test(to_double, [](test_case &) {
+  bool result = true;
+  double val = 8796093022209.0;
+  Datum d = Float8GetDatum(val);
+  result = result &&
+           _assert(cppgres::from_nullable_datum<double>(cppgres::nullable_datum(d), FLOAT8OID) == val);
+
+  return result;
+});
+
+
+} // namespace tests


### PR DESCRIPTION
Noticed some examples:

131073.0 (float4) and 8796093022209.0 (float8) get misinterpreted.

Solution: don't use static_cast

This conversion is not reinterpretation of bits but it uses implicit conversion for the type. And Datum is actually an integer.