### PR TITLE
Problem: no access to current function's collation

### DIFF
--- a/src/cppgres.hpp
+++ b/src/cppgres.hpp
@@ -65,6 +65,7 @@ using ::fmt::format;
 
 #include "cppgres/aggregate.hpp"
 #include "cppgres/bgw.hpp"
+#include "cppgres/collation.hpp"
 #include "cppgres/datum.hpp"
 #include "cppgres/error.hpp"
 #include "cppgres/exception_impl.hpp"

--- a/src/cppgres/collation.hpp
+++ b/src/cppgres/collation.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "datum.hpp"
+#include "imports.h"
+
+namespace cppgres {
+
+struct collation {
+
+  collation(oid oid) : oid_(oid) {}
+
+  [[nodiscard]]
+  std::string name() const {
+    return ffi_guard{::get_collation_name}(oid_);
+  }
+
+private:
+  oid oid_;
+};
+
+} // namespace cppgres

--- a/src/cppgres/function.hpp
+++ b/src/cppgres/function.hpp
@@ -97,6 +97,8 @@ struct function_call_info {
    */
   type return_type() const { return {.oid = ffi_guard{::get_fn_expr_rettype}(info_->flinfo)}; }
 
+  oid collation() const { return info_->fncollation; }
+
 private:
   ::FunctionCallInfo info_;
 };

--- a/src/cppgres/imports.h
+++ b/src/cppgres/imports.h
@@ -49,6 +49,7 @@ extern "C" {
 #include <storage/ipc.h>
 #include <utils/builtins.h>
 #include <utils/expandeddatum.h>
+#include <utils/lsyscache.h>
 #include <utils/memutils.h>
 #include <utils/snapmgr.h>
 #include <utils/syscache.h>

--- a/tests/function.hpp
+++ b/tests/function.hpp
@@ -119,6 +119,9 @@ add_test(current_postgres_function, ([](test_case &) {
            // return type
            result = result && _assert((*ci).return_type() == cppgres::type{.oid = BOOLOID});
 
+           // collation
+           result = result && _assert(cppgres::collation((*ci).collation()).name() == "default");
+
            return result;
          }));
 } // namespace tests


### PR DESCRIPTION
Solution: provide access to collation oid
and a simple wrapper to retrieve collation's name