### PR TITLE
Problem: transforming errors into exceptions

### DIFF
--- a/src/cppgres/guard.hpp
+++ b/src/cppgres/guard.hpp
@@ -39,11 +39,13 @@ template <typename Func> struct ffi_guard {
       ::PG_exception_stack = pbuf;
     });
 
+    auto ih = ::InterruptHoldoffCount;
     state = sigsetjmp(buf, 1);
 
     if (state == 0) {
       return func(std::forward<Args>(args)...);
     } else if (state == 1) {
+      ::InterruptHoldoffCount = ih;
       throw pg_exception(mcxt);
     }
     __builtin_unreachable();

--- a/tests/guard.hpp
+++ b/tests/guard.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "tests.hpp"
+
+namespace tests {
+
+add_test(interrupt_holdoff_count, ([](test_case &) {
+           bool result = true;
+           cppgres::spi_executor spi;
+           cppgres::internal_subtransaction tx;
+           bool exception_raised = false;
+
+           cppgres::ffi_guard{::LWLockAcquire}(AddinShmemInitLock, LW_EXCLUSIVE);
+           result = result && _assert(::InterruptHoldoffCount > 0);
+
+           try {
+             cppgres::internal_subtransaction tx;
+             spi.execute("create tabl a()");
+           } catch (std::exception &e) {
+             exception_raised = true;
+           }
+
+           result = result && _assert(exception_raised);
+           result = result && _assert(::InterruptHoldoffCount > 0);
+
+           cppgres::ffi_guard{::LWLockRelease}(AddinShmemInitLock);
+
+           return result;
+         }));
+
+} // namespace tests

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -29,6 +29,7 @@ PG_MODULE_MAGIC;
 #include "datum.hpp"
 #include "errors.hpp"
 #include "function.hpp"
+#include "guard.hpp"
 #include "heap_tuple.hpp"
 #include "memory_context.hpp"
 #include "node.hpp"


### PR DESCRIPTION
By itself, not a bad idea. This way, the C++ layer can catch them or let them pass through and re-surface as errors.

However, if the process was holding an `LWLock` before, the `InterruptHoldOffCount` would be incremented for each lock, but `errfinish` would just set it to zero on `ERROR`. And when `LWLockRelease` is called, it is asserting that this count should be above zero, resulting in an undefined behavior, or a trap in assertion-enabled mode.

Solution: restore `InterruptHoldOffCount` upon error

`errfinish` says this:

```
We do some minimal cleanup before longjmp'ing so that handlers can
execute in a reasonably sane state.

Reset InterruptHoldoffCount in case we ereport'd from inside an
interrupt holdoff section.  (We assume here that no handler will
itself be inside a holdoff section.  If necessary, such a handler
could **save and restore** InterruptHoldoffCount for itself, but this
should make life easier for most.)
```

(empahsis mine)

Following this logic, this allows us to keep the count correct.