### PR TITLE
Problem: impossible to construct expandable_datum with args

### DIFF
--- a/tests/datum.hpp
+++ b/tests/datum.hpp
@@ -241,6 +241,13 @@ add_test(eoh_smoke, ([](test_case &e) {
            // Ensure destructor gets called on `d`
            result = result && _assert(val == 650);
 
+           // Also, try to pass args into it
+           // (we just check this compiles)
+           auto d = cppgres::expanded_varlena<my_eoh>(1);
+           my_eoh &dv = d;
+           // and the value gets passed
+           result = result && _assert(dv.a == 1);
+
            return result;
          }));
 


### PR DESCRIPTION
So, if constructing the type requires passing arguments to the constructor, we are out of luck.

Solution: allow the passage

Required a bit of concepts voodoo to ensure we don't override the copy/move constructors.