### PR TITLE
Problem: passing functional callbacks into functions

### DIFF
--- a/src/cppgres/datum.hpp
+++ b/src/cppgres/datum.hpp
@@ -18,6 +18,7 @@ struct oid {
   oid() : oid_(InvalidOid) {}
   oid(::Oid oid) : oid_(oid) {}
   oid(oid &oid) : oid_(oid.oid_) {}
+  oid(const oid &oid) : oid_(oid.oid_) {}
 
   bool operator==(const oid &rhs) const { return oid_ == rhs.oid_; }
   bool operator!=(const oid &rhs) const { return !(rhs == *this); }

--- a/src/cppgres/value.hpp
+++ b/src/cppgres/value.hpp
@@ -21,7 +21,7 @@ private:
 template <> struct datum_conversion<value> {
 
   static value from_nullable_datum(const nullable_datum &d, oid oid,
-                                   std::optional<memory_context>) {
+                                   std::optional<memory_context> = std::nullopt) {
     return {nullable_datum(d), type{.oid = oid}};
   }
 
@@ -42,7 +42,7 @@ template <> struct type_traits<value> {
     if (value_.has_value()) {
       return (*value_).get().get_type();
     }
-    throw std::runtime_error("can't determine type for an uninitialized value");
+    return {UNKNOWNOID};
   }
 
 private:


### PR DESCRIPTION
Wouldn't it be cool to do type-safely call functions passed by users? For example, they can provide callbacks.

Solution: extend cppgres::function to support this case

Had to fix a few bugs to achieve this!