### PR TITLE
Problem: not reading C and C++ ABI dumps correctly

### DIFF
--- a/scripts/abi_layout.py
+++ b/scripts/abi_layout.py
@@ -8,7 +8,8 @@ def parse_clang_layout(file_path):
     structs = {}
     current_struct = None
     field_pattern = re.compile(r"^\s*(\d+)\s*\|\s\s\s([^\s].+)")
-    size_pattern = re.compile(r"^\s*\[\s*sizeof=(\d+),\s*align=(\d+)\s*\]")
+    size_pattern = re.compile(r"^\s*\|?\s*\[\s*sizeof=(\d+),(?:\s*dsize=\d+,)?\s*align=(\d+)\s*")
+
 
     previous_line_was_marker = False
 


### PR DESCRIPTION
When we are checking for ABI, both C and C++ sizing for records was not captured and we were checking None with None.

We were still checking the offsets, though.

Solution: ensure our regexp captures it better