### PR TITLE
Problem: unsure if expandable value avoids flattening

### DIFF
--- a/src/cppgres/memory.hpp
+++ b/src/cppgres/memory.hpp
@@ -31,7 +31,7 @@ struct abstract_memory_context {
 
   ::MemoryContextCallback *register_reset_callback(::MemoryContextCallbackFunction func,
                                                    void *arg) {
-    auto cb = alloc<::MemoryContextCallback>(sizeof(::MemoryContextCallback));
+    auto cb = alloc<::MemoryContextCallback>();
     cb->func = func;
     cb->arg = arg;
     ffi_guard{::MemoryContextRegisterResetCallback}(_memory_context(), cb);


### PR DESCRIPTION
Solution: let's write a tesst

Most important discovery: we weren't! Ensure we check whether it is an expanded pointer in T&() before trying to proceed and detoast.

While testing, found a few issues to fix:

1. Over-allocation of memory for reset callback in memory contexts
2. Don't inherit from `type` in `non_by_value_type` – they are different hierarchies. Ideally, we shouldn't call it `_type`, it doesn't describe a type but value.
3. Initialize expandable object in its own memory context

Also, decided to use argument forwarding to initialize the `inner` part of the expanded object.