### PR TITLE
Problem: lack of role / security management

### DIFF
--- a/src/cppgres.hpp
+++ b/src/cppgres.hpp
@@ -76,6 +76,7 @@ using ::fmt::format;
 #include "cppgres/memory.hpp"
 #include "cppgres/node.hpp"
 #include "cppgres/record.hpp"
+#include "cppgres/role.hpp"
 #include "cppgres/set.hpp"
 #include "cppgres/threading.hpp"
 #include "cppgres/types.hpp"

--- a/src/cppgres/datum.hpp
+++ b/src/cppgres/datum.hpp
@@ -29,6 +29,8 @@ struct oid {
   operator ::Oid() const { return oid_; }
   operator ::Oid &() { return oid_; }
 
+  bool is_valid() const { return oid_ != InvalidOid; }
+
 private:
   ::Oid oid_;
 };

--- a/src/cppgres/imports.h
+++ b/src/cppgres/imports.h
@@ -51,6 +51,7 @@ extern "C" {
 #include <parser/parse_func.h>
 #include <parser/parser.h>
 #include <storage/ipc.h>
+#include <utils/acl.h>
 #include <utils/builtins.h>
 #include <utils/expandeddatum.h>
 #include <utils/lsyscache.h>

--- a/src/cppgres/role.hpp
+++ b/src/cppgres/role.hpp
@@ -1,0 +1,79 @@
+/**
+ * \file
+ */
+#pragma once
+
+#include <optional>
+#include <span>
+#include <string>
+#include <utility>
+
+#include "datum.hpp"
+#include "syscache.hpp"
+#include "type.hpp"
+
+namespace cppgres {
+
+struct role : oid {
+  using oid::oid;
+  role() : oid(::GetCurrentRoleId() != InvalidOid ? ::GetCurrentRoleId() : ::GetUserId()) {}
+  role(std::string role_name) : oid(ffi_guard{::get_role_oid}(role_name.c_str(), false)) {}
+
+  std::string_view name() const { return ffi_guard{::GetUserNameFromId}(*this, false); }
+
+  bool is_member(role &other, bool ignore_superuser = false) {
+    return ffi_guard{ignore_superuser ? ::is_member_of_role_nosuper : ::is_member_of_role}(*this,
+                                                                                           other);
+  }
+};
+
+template <> struct type_traits<role> {
+  static bool is(const type &t) { return t.oid == OIDOID || t.oid == REGROLEOID; }
+  static constexpr type type_for() { return type{.oid = REGROLEOID}; }
+};
+
+template <> struct datum_conversion<role> : default_datum_conversion<role> {
+  static role from_datum(const datum &d, oid, std::optional<memory_context>) {
+    return static_cast<role>(d.operator const ::Datum &());
+  }
+
+  static datum into_datum(const role &t) { return datum(static_cast<::Datum>(t)); }
+};
+
+enum security_context_flag : int {
+  security_none = 0x0000,
+  security_local_user_id_change = SECURITY_LOCAL_USERID_CHANGE,
+  security_restricted_operation = SECURITY_RESTRICTED_OPERATION,
+  security_noforce_rls = SECURITY_NOFORCE_RLS
+};
+
+constexpr security_context_flag operator|(security_context_flag a, security_context_flag b) {
+  return static_cast<security_context_flag>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+constexpr security_context_flag operator&(security_context_flag a, security_context_flag b) {
+  return static_cast<security_context_flag>(static_cast<int>(a) & static_cast<int>(b));
+}
+
+constexpr security_context_flag &operator|=(security_context_flag &a, security_context_flag b) {
+  return a = a | b;
+}
+
+struct security_context {
+  security_context(role r, security_context_flag context = security_none) : role_(r) {
+    ::GetUserIdAndSecContext(&user, &ctx);
+    ::SetUserIdAndSecContext(role_, context);
+  }
+  ~security_context() { ::SetUserIdAndSecContext(user, ctx); }
+
+  static bool in_local_user_id_change() { return ::InLocalUserIdChange(); }
+  static bool in_security_restricted_operation() { return ::InSecurityRestrictedOperation(); }
+  static bool in_no_force_rls_operation() { return ::InNoForceRLSOperation(); }
+
+private:
+  role role_;
+  ::Oid user;
+  int ctx;
+};
+
+} // namespace cppgres

--- a/tests/role.hpp
+++ b/tests/role.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "tests.hpp"
+
+namespace tests {
+
+add_test(current_role, ([](test_case &) {
+           bool result = true;
+           cppgres::role role;
+           result = result && _assert(role.is_valid());
+           return result;
+         }));
+
+add_test(find_a_role, ([](test_case &) {
+           bool result = true;
+
+           {
+             cppgres::spi_executor spi;
+             spi.execute("create role findthisrole");
+             cppgres::role role("findthisrole");
+             result = result && _assert(role.name() == "findthisrole");
+             result = result && _assert(role.is_valid());
+           }
+
+           {
+             bool exception_raised = false;
+             cppgres::internal_subtransaction tx;
+             try {
+               cppgres::role role("thisroledoesnotexist");
+             } catch (std::exception) {
+               exception_raised = true;
+             }
+             result = result && _assert(exception_raised);
+           }
+           return result;
+         }));
+
+add_test(membership, ([](test_case &) {
+           bool result = true;
+
+           cppgres::spi_executor spi;
+           spi.execute("create role role1");
+           spi.execute("create role role2");
+           spi.execute("grant role2 to role1");
+           cppgres::role role1("role1");
+           cppgres::role role2("role2");
+
+           result = result && _assert(role1.is_member(role2));
+           result = result && _assert(!role2.is_member(role1));
+
+           return result;
+         }));
+
+add_test(security_context, ([](test_case &) {
+           bool result = true;
+
+           cppgres::spi_executor spi;
+           spi.execute("create role sectx1");
+           cppgres::role role("sectx1");
+           {
+             cppgres::security_context ctx(role);
+             result = result && _assert(cppgres::role() == role);
+           }
+           result = result && _assert(cppgres::role() != role);
+
+           return result;
+         }));
+
+add_test(security_context_escape, ([](test_case &) {
+           bool result = true;
+
+           cppgres::spi_executor spi;
+           spi.execute("create role sectx2_other");
+           spi.execute("create role sectx2");
+           cppgres::role role("sectx2");
+           {
+             cppgres::security_context ctx(role, cppgres::security_local_user_id_change);
+             {
+               bool exception_raised = false;
+               try {
+                 cppgres::internal_subtransaction tx;
+                 spi.execute("set role sectx2_other");
+               } catch (std::exception) {
+                 exception_raised = true;
+               }
+               result = result && _assert(exception_raised);
+             }
+             {
+               bool exception_raised = false;
+               try {
+                 cppgres::internal_subtransaction tx;
+                 spi.execute("reset role");
+               } catch (std::exception) {
+                 exception_raised = true;
+               }
+               result = result && _assert(exception_raised);
+             }
+           }
+           result = result && _assert(cppgres::role() != role);
+
+           return result;
+         }));
+
+} // namespace tests

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -33,6 +33,7 @@ PG_MODULE_MAGIC;
 #include "memory_context.hpp"
 #include "node.hpp"
 #include "record.hpp"
+#include "role.hpp"
 #include "spi.hpp"
 #include "srf.hpp"
 #include "syscache.hpp"


### PR DESCRIPTION
It's possible to use, but only through C APIs, which can be a bit more tedious than desirable.

Solution: add some simple `role` and `security_context` wrappers