### PR TITLE
Problem: order of types in the `function` template

### DIFF
--- a/src/cppgres/function.hpp
+++ b/src/cppgres/function.hpp
@@ -350,14 +350,7 @@ template <datumable_function Func> struct postgres_function {
   }
 };
 
-template <has_type_traits... Arg> struct function {
-
-  template <std::size_t... I>
-  static auto make_arg_tuple(std::index_sequence<I...>)
-      -> std::tuple<std::tuple_element_t<I, std::tuple<Arg...>>...>;
-
-  using arg_types = decltype(make_arg_tuple(std::make_index_sequence<sizeof...(Arg) - 1>{}));
-  using ret_type = std::tuple_element_t<sizeof...(Arg) - 1, std::tuple<Arg...>>;
+template <has_type_traits ret_type, has_type_traits... arg_types> struct function {
 
   function() = delete;
 
@@ -366,8 +359,9 @@ template <has_type_traits... Arg> struct function {
           return alloc_set_memory_context()([&schema, &name]() {
             ::List *fname = list_make2(::makeString(const_cast<char *>(schema)),
                                        ::makeString(const_cast<char *>(name)));
-            std::array<::Oid, sizeof...(Arg)> argtypes = {type_traits<Arg>().type_for().oid...};
-            return ffi_guard{::LookupFuncName}(fname, static_cast<int>(sizeof...(Arg) - 1),
+            std::array<::Oid, sizeof...(arg_types)> argtypes = {
+                type_traits<arg_types>().type_for().oid...};
+            return ffi_guard{::LookupFuncName}(fname, static_cast<int>(sizeof...(arg_types)),
                                                argtypes.data(), false);
           });
         }()) {}
@@ -376,8 +370,9 @@ template <has_type_traits... Arg> struct function {
       : function([name]() -> oid {
           return alloc_set_memory_context()([&name]() {
             ::List *fname = list_make1(::makeString(const_cast<char *>(name)));
-            std::array<::Oid, sizeof...(Arg)> argtypes = {type_traits<Arg>().type_for().oid...};
-            return ffi_guard{::LookupFuncName}(fname, static_cast<int>(sizeof...(Arg) - 1),
+            std::array<::Oid, sizeof...(arg_types)> argtypes = {
+                type_traits<arg_types>().type_for().oid...};
+            return ffi_guard{::LookupFuncName}(fname, static_cast<int>(sizeof...(arg_types)),
                                                argtypes.data(), false);
           });
         }()) {}
@@ -386,7 +381,7 @@ template <has_type_traits... Arg> struct function {
     syscache<Form_pg_proc, decltype(oid)> p(oid_);
     // Check arguments
     auto &argtypes = (*p).proargtypes;
-    std::array<type, sizeof...(Arg)> types = {type_traits<Arg>().type_for()...};
+    std::array<type, sizeof...(arg_types)> types = {type_traits<arg_types>().type_for()...};
     for (int i = 0; i < argtypes.dim1; i++) {
       cppgres::oid arg(argtypes.values[i]);
       if (types[i] != type{UNKNOWNOID} /* FIXME: figure out how to avoid this special case */ &&
@@ -407,15 +402,15 @@ template <has_type_traits... Arg> struct function {
     strict_ = (*p).proisstrict;
   }
 
-  using self = function<Arg...>;
+  using self = function<ret_type, arg_types...>;
   template <typename... Args> static constexpr bool convertible_args() {
-    if constexpr (sizeof...(Args) != sizeof...(Arg) - 1) {
+    if constexpr (sizeof...(Args) != sizeof...(arg_types)) {
       return false;
     } else {
       return []<std::size_t... I>(std::index_sequence<I...>) {
-        return (
-            std::convertible_to<std::decay_t<Args>, std::tuple_element_t<I, std::tuple<Arg...>>> &&
-            ...);
+        return (std::convertible_to<std::decay_t<Args>,
+                                    std::tuple_element_t<I, std::tuple<arg_types...>>> &&
+                ...);
       }(std::make_index_sequence<sizeof...(Args)>{});
     }
   }
@@ -423,7 +418,7 @@ template <has_type_traits... Arg> struct function {
   {
     bool any_nulls = false;
     auto optval = []<std::size_t I>(auto arg) -> ::Datum {
-      using nth_type = std::tuple_element_t<I, std::tuple<Arg...>>;
+      using nth_type = std::tuple_element_t<I, std::tuple<arg_types...>>;
       if constexpr (std::same_as<std::nullopt_t, decltype(arg)>) {
         return datum(0);
       } else if constexpr (!utils::is_optional<decltype(arg)>) {
@@ -451,7 +446,7 @@ template <has_type_traits... Arg> struct function {
 
       ffi_guard{::fmgr_info}(oid_, &flinfo);
 
-      InitFunctionCallInfoData(*fcinfo, &flinfo, sizeof...(args), InvalidOid, NULL, NULL);
+      InitFunctionCallInfoData(*fcinfo, &flinfo, sizeof...(args), InvalidOid, nullptr, nullptr);
 
       ((fcinfo->args[I].value = optval.template operator()<I>(args)), ...);
       ((fcinfo->args[I].isnull = isnull(args)), ...);
@@ -470,7 +465,7 @@ template <has_type_traits... Arg> struct function {
       }
 
       return datum_conversion<ret_type>().from_nullable_datum(result, rettype_);
-    }(std::make_index_sequence<sizeof...(Arg) - 1>{});
+    }(std::make_index_sequence<sizeof...(args)>{});
   }
 
   const oid &function_oid() const { return oid_; }
@@ -481,50 +476,50 @@ private:
   bool strict_;
 };
 
-template <has_type_traits... Args>
-struct datum_conversion<function<Args...>> : default_datum_conversion<function<Args...>> {
-  static function<Args...> from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
+template <has_type_traits ret, has_type_traits... Args>
+struct datum_conversion<function<ret, Args...>> : default_datum_conversion<function<ret, Args...>> {
+  static function<ret, Args...> from_datum(const datum &d, oid, std::optional<memory_context> ctx) {
     return {oid(d)};
   }
 
-  static datum into_datum(const function<Args...> &t) {
+  static datum into_datum(const function<ret, Args...> &t) {
     return datum_conversion<oid>::into_datum(t.function_oid());
   }
 };
 
-template <has_type_traits... Args> struct type_traits<function<Args...>> {
+template <has_type_traits ret, has_type_traits... Args> struct type_traits<function<ret, Args...>> {
   static bool is(const type &t) {
     return t.oid == REGPROCEDUREOID || t.oid == OIDOID || t.oid == REGPROCOID;
   }
   static constexpr type type_for() { return type{.oid = REGPROCEDUREOID}; }
 };
 
-template <has_type_traits T> function<T, const char *> output_function() {
+template <has_type_traits T> function<const char *, T> output_function() {
   ::Oid foutoid;
   bool typisvarlena;
   ffi_guard{::getTypeOutputInfo}(type_traits<T>().type_for().oid, &foutoid, &typisvarlena);
-  return function<T, const char *>(foutoid);
+  return function<const char *, T>(foutoid);
 }
 
-template <has_type_traits T> function<T, const char *> output_function(T &&v) {
+template <has_type_traits T> function<const char *, T> output_function(T &&v) {
   ::Oid foutoid;
   bool typisvarlena;
   ffi_guard{::getTypeOutputInfo}(type_traits<T>(v).type_for().oid, &foutoid, &typisvarlena);
-  return function<T, const char *>(foutoid);
+  return function<const char *, T>(foutoid);
 }
 
-template <has_type_traits T> function<T, const char *> output_function(T &v) {
+template <has_type_traits T> function<const char *, T> output_function(T &v) {
   ::Oid foutoid;
   bool typisvarlena;
   ffi_guard{::getTypeOutputInfo}(type_traits<T>(v).type_for().oid, &foutoid, &typisvarlena);
-  return function<T, const char *>(foutoid);
+  return function<const char *, T>(foutoid);
 }
 
-static function<cppgres::value, const char *> output_function(const type &t) {
+static function<const char *, cppgres::value> output_function(const type &t) {
   ::Oid foutoid;
   bool typisvarlena;
   ffi_guard{::getTypeOutputInfo}(t.oid, &foutoid, &typisvarlena);
-  return function<cppgres::value, const char *>(foutoid);
+  return function<const char *, cppgres::value>(foutoid);
 }
 
 } // namespace cppgres

--- a/tests/function.hpp
+++ b/tests/function.hpp
@@ -129,18 +129,18 @@ add_test(function_call, ([](test_case &) {
            bool result = true;
 
            {
-             cppgres::function<std::string, int32_t> f("length");
+             cppgres::function<int32_t, std::string> f("length");
              result = result && _assert(f("test") == 4);
            }
 
            {
-             cppgres::function<std::optional<std::string>, std::optional<int32_t>> f("length");
+             cppgres::function<std::optional<int32_t>, std::optional<std::string>> f("length");
              result = result && _assert(f("test").value() == 4);
              result = result && _assert(!f(std::nullopt).has_value());
            }
 
            {
-             cppgres::function<std::string, int32_t> f("pg_catalog", "length");
+             cppgres::function<int32_t, std::string> f("pg_catalog", "length");
              result = result && _assert(f("test") == 4);
            }
 
@@ -151,7 +151,7 @@ add_test(function_call, ([](test_case &) {
              cppgres::internal_subtransaction sub;
              bool exception_raised = false;
              try {
-               cppgres::function<std::int32_t, int32_t> f("length");
+               cppgres::function<int32_t, std::int32_t> f("length");
              } catch (std::exception &e) {
                result =
                    result &&
@@ -166,7 +166,7 @@ add_test(function_call, ([](test_case &) {
              cppgres::internal_subtransaction sub;
              bool exception_raised = false;
              try {
-               cppgres::function<std::string, std::string, int32_t> f("length");
+               cppgres::function<int32_t, std::string, std::string> f("length");
              } catch (std::exception &e) {
                result = result &&
                         _assert(std::string_view("function length(text, text) does not exist") ==
@@ -196,7 +196,7 @@ add_test(function_call, ([](test_case &) {
              cppgres::internal_subtransaction sub;
              bool exception_raised = false;
              try {
-               cppgres::function<std::string, int32_t> f("lengt");
+               cppgres::function<int32_t, std::string> f("lengt");
              } catch (std::exception &e) {
                result = result && _assert(std::string_view("function lengt(text) does not exist") ==
                                           e.what());
@@ -209,7 +209,7 @@ add_test(function_call, ([](test_case &) {
          }));
 
 // Function that takes a function
-postgres_function(function_arg, ([](cppgres::function<std::string_view, std::int32_t> f,
+postgres_function(function_arg, ([](cppgres::function<std::int32_t, std::string_view> f,
                                     std::string_view s) { return f(s); }));
 
 add_test(function_takes_a_function, ([](test_case &) {


### PR DESCRIPTION
Syntactically, it follows how we define functions in Postgres:

```sql
create function length(text) returns int
```
(`text -> int`)

This, however, makes the template awkward to use and it's harder to select the return type as it's the last one in the list of arguments.

And, more importantly, what if needs to have different constraints? For example, I can see how SRF return types may be different.

Solution: change the order of types in the template argument

The new one will follow the traditional C/C++ order:

```c++
int length(std::string)
```

This will make it `int <- string`, putting the return type first.