### PR TITLE
Problem: can't compile multi-parameter query

### DIFF
--- a/src/cppgres/executor.hpp
+++ b/src/cppgres/executor.hpp
@@ -323,7 +323,7 @@ struct spi_executor : public executor {
       throw std::runtime_error("not a current SPI executor");
     }
     constexpr size_t nargs = sizeof...(Args);
-    std::array<::Oid, nargs> types = {type_traits<Args>(args...).type_for().oid...};
+    std::array<::Oid, nargs> types = {type_traits<Args>(args).type_for().oid...};
     std::array<::Datum, nargs> datums = {into_nullable_datum(args)...};
     std::array<const char, nargs> nulls = {into_nullable_datum(args).is_null() ? 'n' : ' ' ...};
     auto rc = ffi_guard{::SPI_execute_with_args}(utils::to_cstring(query), nargs, types.data(),
@@ -388,7 +388,7 @@ struct spi_executor : public executor {
       throw std::runtime_error("not a current SPI executor");
     }
     constexpr size_t nargs = sizeof...(Args);
-    std::array<::Oid, nargs> types = {type_traits<Args>(args...).type_for().oid...};
+    std::array<::Oid, nargs> types = {type_traits<Args>(args).type_for().oid...};
     std::array<::Datum, nargs> datums = {into_nullable_datum(args)...};
     std::array<const char, nargs> nulls = {into_nullable_datum(args).is_null() ? 'n' : ' ' ...};
     auto rc = ffi_guard{::SPI_execute_with_args}(query.data(), nargs, types.data(), datums.data(),

--- a/tests/spi.hpp
+++ b/tests/spi.hpp
@@ -23,6 +23,21 @@ add_test(spi, ([](test_case &) {
            return result;
          }));
 
+add_test(spi_multiparam, ([](test_case &) {
+           bool result = true;
+           cppgres::spi_executor spi;
+           auto res = spi.query<std::tuple<std::optional<int64_t>>>(
+               "select $1 + $2 + i from generate_series(1,100) i", static_cast<int64_t>(1LL),
+               static_cast<int64_t>(1LL));
+
+           int i = 0;
+           for (auto &re : res) {
+             i++;
+             result = result && _assert(std::get<0>(re) == i + 2);
+           }
+           return result;
+         }));
+
 add_test(spi_single, ([](test_case &) {
            bool result = true;
            cppgres::spi_executor spi;


### PR DESCRIPTION
```c++
spi.query<...>("query", val1, val2, val3);
```

Results in passing more than one argument to `type_traits<valN>`.

Solution: ensure we expand pack correctly