### PR TITLE
Problem: can't compile on some systems

### DIFF
--- a/src/cppgres/threading.hpp
+++ b/src/cppgres/threading.hpp
@@ -8,6 +8,7 @@
 
 #ifdef __linux__
 #include <sys/syscall.h>
+#define _GNU_SOURCE
 #include <unistd.h>
 #elif __APPLE__
 #include <pthread.h>


### PR DESCRIPTION
`gettid()` is not defined

Solution: ensure we specify _GNU_SOURCE
to enable this functionality