### PR TITLE
Problem: warning about overriding _GNU_SOURCE if defined

### DIFF
--- a/src/cppgres/threading.hpp
+++ b/src/cppgres/threading.hpp
@@ -8,7 +8,9 @@
 
 #ifdef __linux__
 #include <sys/syscall.h>
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
 #include <unistd.h>
 #elif __APPLE__
 #include <pthread.h>


### PR DESCRIPTION
Solution: define it only if it isn't