### PR TITLE
Make internal_subtransaction nestable, scope-aware, and noexcept

### DIFF
--- a/src/cppgres/xact.hpp
+++ b/src/cppgres/xact.hpp
@@ -3,11 +3,15 @@
  */
 #pragma once
 
-#include <stack>
+#include <exception>
+#include <string>
+#include <string_view>
 
 extern "C" {
 #include <access/xact.h>
 }
+
+#include "guard.hpp"
 
 namespace cppgres {
 
@@ -47,42 +51,86 @@ private:
 
 static_assert(sizeof(transaction_id) == sizeof(::TransactionId));
 
+/**
+ * @brief Internal subtransaction guard
+ *
+ * Begins an internal subtransaction on construction and finishes it exactly
+ * once. Subtransactions nest (as PL exception blocks do).
+ *
+ * If the scope is left because an exception is propagating, the
+ * subtransaction is rolled back; otherwise, at scope exit it is committed
+ * (default) or rolled back per the flag given at construction. Alternatively,
+ * it can be finished early by calling commit() or rollback() explicitly.
+ *
+ * `CurrentMemoryContext` and `CurrentResourceOwner` observed at construction
+ * are restored on every path.
+ */
 struct internal_subtransaction {
   internal_subtransaction(bool commit = true)
-      : owner(::CurrentResourceOwner), commit(commit), name("") {
-    if (txns.empty()) {
-      ffi_guard{::BeginInternalSubTransaction}(nullptr);
-      txns.push(this);
-    } else {
-      throw std::runtime_error("internal subtransaction already started");
-    }
+      : ctx(::CurrentMemoryContext), owner(::CurrentResourceOwner), should_commit(commit),
+        uncaught(std::uncaught_exceptions()), finished(false), name("") {
+    ffi_guard{::BeginInternalSubTransaction}(nullptr);
+    ::CurrentMemoryContext = ctx;
   }
 
   internal_subtransaction(std::string_view name, bool commit = true)
-      : owner(::CurrentResourceOwner), commit(commit), name(name) {
-    if (txns.empty()) {
-      ffi_guard{::BeginInternalSubTransaction}(this->name.c_str());
-      txns.push(this);
-    } else {
-      throw std::runtime_error("internal subtransaction already started");
-    }
+      : ctx(::CurrentMemoryContext), owner(::CurrentResourceOwner), should_commit(commit),
+        uncaught(std::uncaught_exceptions()), finished(false), name(name) {
+    ffi_guard{::BeginInternalSubTransaction}(this->name.c_str());
+    ::CurrentMemoryContext = ctx;
   }
 
-  ~internal_subtransaction() {
-    txns.pop();
-    if (commit) {
-      ffi_guard{::ReleaseCurrentSubTransaction}();
-    } else {
-      ffi_guard{::RollbackAndReleaseCurrentSubTransaction}();
+  internal_subtransaction(const internal_subtransaction &) = delete;
+  internal_subtransaction &operator=(const internal_subtransaction &) = delete;
+  internal_subtransaction(internal_subtransaction &&) = delete;
+  internal_subtransaction &operator=(internal_subtransaction &&) = delete;
+
+  /**
+   * @brief Commit the subtransaction now
+   */
+  void commit() {
+    ffi_guard{::ReleaseCurrentSubTransaction}();
+    restore();
+    finished = true;
+  }
+
+  /**
+   * @brief Roll the subtransaction back now
+   */
+  void rollback() {
+    ffi_guard{::RollbackAndReleaseCurrentSubTransaction}();
+    restore();
+    finished = true;
+  }
+
+  ~internal_subtransaction() noexcept {
+    if (finished) {
+      return;
     }
-    ::CurrentResourceOwner = owner;
+    ffi_guard_noexcept(
+        [this] {
+          if (std::uncaught_exceptions() > uncaught || !should_commit) {
+            ::RollbackAndReleaseCurrentSubTransaction();
+          } else {
+            ::ReleaseCurrentSubTransaction();
+          }
+        },
+        "cppgres: finishing internal subtransaction failed");
+    restore();
   }
 
 private:
+  void restore() noexcept {
+    ::CurrentMemoryContext = ctx;
+    ::CurrentResourceOwner = owner;
+  }
+
+  ::MemoryContext ctx;
   ::ResourceOwner owner;
-  bool commit;
+  bool should_commit;
+  int uncaught;
+  bool finished;
   std::string name;
-  static inline std::stack<internal_subtransaction *> txns;
 };
 
 struct transaction {

--- a/tests/xact.hpp
+++ b/tests/xact.hpp
@@ -8,13 +8,11 @@ add_test(internal_subtransaction_one, ([](test_case &) {
            bool result = true;
            {
              cppgres::internal_subtransaction sub;
-             bool exception_raised = false;
-             try {
-               cppgres::internal_subtransaction sub;
-             } catch (std::runtime_error &e) {
-               exception_raised = true;
+             {
+               // subtransactions nest, as procedural-language exception
+               // blocks do
+               cppgres::internal_subtransaction inner;
              }
-             result = result && _assert(exception_raised);
            }
            {
              // doing it again is fine

--- a/tests/xact.hpp
+++ b/tests/xact.hpp
@@ -56,4 +56,26 @@ add_test(internal_subtransaction_rollback, ([](test_case &) {
            result = result && _assert(std::get<0>(res.begin()[0]) == 0);
            return result;
          }));
+
+add_test(internal_subtransaction_exception_rolls_back, ([](test_case &) {
+           bool result = true;
+           {
+             cppgres::spi_executor spi;
+             spi.execute("create table internal_subtransaction_exception ()");
+           }
+           try {
+             // Constructed to commit at scope exit — but the scope is left
+             // via an exception, so it must roll back instead.
+             cppgres::internal_subtransaction sub;
+             cppgres::spi_executor spi;
+             spi.execute("insert into internal_subtransaction_exception default values");
+             throw std::runtime_error("unwind");
+           } catch (std::runtime_error &) {
+           }
+           cppgres::spi_executor spi;
+           auto res = spi.query<std::tuple<int64_t>>(
+               "select count(*) from internal_subtransaction_exception");
+           result = result && _assert(std::get<0>(res.begin()[0]) == 0);
+           return result;
+         }));
 } // namespace tests


### PR DESCRIPTION
This is the one piece of the uplpgsql-driven cppgres batch that changes an existing type's documented contract, so it comes as a PR rather than a direct push (everything additive went to master and is green there).

**What changes**

`internal_subtransaction` previously kept a process-wide singleton stack and threw `std::runtime_error` on nested construction — asserted by `internal_subtransaction_one`. Procedural-language implementations (PL exception blocks) nest subtransactions as a matter of course, and the type also couldn't express the common commit-on-success/rollback-on-exception pattern (its polarity was fixed at construction), and its destructor could throw during unwinding.

With this PR it:
- nests (singleton stack and its throw removed);
- saves/restores both `CurrentMemoryContext` and `CurrentResourceOwner`;
- supports explicit `commit()` / `rollback()`;
- has a `noexcept` destructor: rolls back when the scope is left via an exception (`std::uncaught_exceptions`), otherwise honors the constructed flag, degrading any failure to a `WARNING` via `ffi_guard_noexcept`.

The `internal_subtransaction_one` test's no-nesting assertion is replaced with a nesting test; the commit/rollback tests are untouched and pass.

**Provenance / validation**: extracted from the uplpgsql PL/pgSQL-JIT rewrite, where it backs the JIT-compile fallback and interpreter exception blocks; that consumer's 15-test regression suite (including its exception-heavy trap tests) is green with this exact code, and cppgres's own suite passes 100% on this branch (PG 18.4 Debug, macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)